### PR TITLE
fixed margins and padding of table and drag icon

### DIFF
--- a/components/system/components/ListEditor.js
+++ b/components/system/components/ListEditor.js
@@ -54,7 +54,6 @@ const STYLES_BUTTON = css`
 const STYLES_DELETE = css`
   box-sizing: border-box;
   height: 18px;
-  margin-top: 1px;
   cursor: pointer;
   color: ${Constants.system.darkGray};
   justify-self: end;
@@ -67,7 +66,7 @@ const STYLES_DELETE = css`
 const STYLES_REORDER = css`
   box-sizing: border-box;
   height: 14px;
-  margin-top: 1px;
+  margin-top: 4px;
   cursor: grab;
   color: ${Constants.system.darkGray};
   justify-self: start;

--- a/components/system/components/fragments/TableComponents.js
+++ b/components/system/components/fragments/TableComponents.js
@@ -99,7 +99,7 @@ const STYLES_TOP_COLUMN = css`
 
 const STYLES_CONTENT = css`
   box-sizing: border-box;
-  padding: 12px 12px 16px 12px;
+  padding: 12px 12px 12px 12px;
   min-width: 10%;
   width: 100%;
   align-self: stretch;


### PR DESCRIPTION
Made some tiny tweaks to center margins and padding for tables and drag icon in list editor.

Drag Icon Margins
![Group 1](https://user-images.githubusercontent.com/1757261/87871597-fe558c80-c9e3-11ea-8204-6fcf7b9b30d2.png)


Table Padding
![Group 2](https://user-images.githubusercontent.com/1757261/87871598-0281aa00-c9e4-11ea-84ed-fe18403b649a.png)
