### PR TITLE
added consistency and a new color to link styles

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -40,6 +40,7 @@ export const system = {
   black: "#2D2926",
   pitchBlack: "#0c0c0c",
   brand: "#2935ff",
+  link: "#0074D9",
   green: "#28a745",
   yellow: " #FFC940",
   red: "#ff0000",

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -3,6 +3,21 @@ import * as Constants from "~/common/constants";
 
 import { css } from "@emotion/react";
 
+const ANCHOR = `
+  a {
+    font-family: ${Constants.font.text};
+    font-weight: 400;
+    text-decoration: none;
+    color: ${Constants.system.link};
+  }
+
+  a:hover {
+    text-decoration: underline;
+    color: ${Constants.system.link};
+
+  }
+`;
+
 const STYLES_H1 = css`
   box-sizing: border-box;
   font-size: ${Constants.typescale.lvl4};
@@ -25,10 +40,12 @@ const STYLES_H1 = css`
     font-family: ${Constants.font.semiBold};
     font-weight: 400;
   }
+
+  ${ANCHOR}
 `;
 
 export const H1 = (props) => {
-  return <h1 css={css`${STYLES_H1};${ANCHOR};`} {...props} />;
+  return <h1 css={STYLES_H1} {...props} />;
 };
 
 const STYLES_H2 = css`
@@ -55,10 +72,11 @@ const STYLES_H2 = css`
     font-weight: 400;
   }
 
+  ${ANCHOR}
 `;
 
 export const H2 = (props) => {
-  return <h2 css={css`${STYLES_H2};${ANCHOR};`} {...props} />;
+  return <h2 css={STYLES_H2} {...props} />;
 };
 
 const STYLES_H3 = css`
@@ -84,10 +102,11 @@ const STYLES_H3 = css`
     font-weight: 400;
   }
 
+  ${ANCHOR}
 `;
 
 export const H3 = (props) => {
-  return <h3 css={css`${STYLES_H3};${ANCHOR};`} {...props} />;
+  return <h3 css={STYLES_H3} {...props} />;
 };
 
 const STYLES_H4 = css`
@@ -112,10 +131,12 @@ const STYLES_H4 = css`
     font-family: ${Constants.font.semiBold};
     font-weight: 400;
   }
+
+  ${ANCHOR}
 `;
 
 export const H4 = (props) => {
-  return <h4 css={css`${STYLES_H4};${ANCHOR};`} {...props} />;
+  return <h4 css={STYLES_H4} {...props} />;
 };
 
 const STYLES_P = css`
@@ -129,11 +150,12 @@ const STYLES_P = css`
     font-family: ${Constants.font.semiBold};
     font-weight: 400;
   }
-  
+
+  ${ANCHOR}
 ` ;
 
 export const P = (props) => {
-  return <div css={css`${STYLES_P};${ANCHOR};`} {...props}></div>;
+  return <div css={STYLES_P} {...props}/>;
 };
 
 const STYLES_UL = css`
@@ -142,7 +164,7 @@ const STYLES_UL = css`
 `;
 
 export const UL = (props) => {
-  return <ul css={css`${STYLES_UL};${ANCHOR};`} {...props} />;
+  return <ul css={STYLES_UL} {...props} />;
 };
 
 const STYLES_OL = css`
@@ -151,7 +173,7 @@ const STYLES_OL = css`
 `;
 
 export const OL = (props) => {
-  return <ol css={css`${STYLES_OL};${ANCHOR};`} {...props} />;
+  return <ol css={STYLES_OL} {...props} />;
 };
 
 const STYLES_LI = css`
@@ -163,23 +185,10 @@ const STYLES_LI = css`
     font-weight: 400;
   }
 
+  ${ANCHOR}
 `;
 
 export const LI = (props) => {
-  return <li css={css`${STYLES_LI};${ANCHOR};`} {...props} />;
+  return <li css={STYLES_LI} {...props} />;
 };
 
-const ANCHOR = css`
-  a {
-    font-family: ${Constants.font.text};
-    font-weight: 400;
-    text-decoration: none;
-    color: ${Constants.system.link};
-  }
-
-  a:hover {
-    text-decoration: underline;
-    color: ${Constants.system.link};
-
-  }
-`;

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -28,11 +28,7 @@ const STYLES_H1 = css`
 `;
 
 export const H1 = (props) => {
-  if (props.href) {
-    return <a css={STYLES_H1} {...props} />;
-  }
-
-  return <h1 css={STYLES_H1} {...props} />;
+  return <h1 css={css`${STYLES_H1};${ANCHOR};`} {...props} />;
 };
 
 const STYLES_H2 = css`
@@ -58,14 +54,11 @@ const STYLES_H2 = css`
     font-family: ${Constants.font.semiBold};
     font-weight: 400;
   }
+
 `;
 
 export const H2 = (props) => {
-  if (props.href) {
-    return <a css={STYLES_H2} {...props} />;
-  }
-
-  return <h2 css={STYLES_H2} {...props} />;
+  return <h2 css={css`${STYLES_H2};${ANCHOR};`} {...props} />;
 };
 
 const STYLES_H3 = css`
@@ -90,17 +83,14 @@ const STYLES_H3 = css`
     font-family: ${Constants.font.semiBold};
     font-weight: 400;
   }
+
 `;
 
 export const H3 = (props) => {
-  if (props.href) {
-    return <a css={STYLES_H3} {...props} />;
-  }
-
-  return <h3 css={STYLES_H3} {...props} />;
+  return <h3 css={css`${STYLES_H3};${ANCHOR};`} {...props} />;
 };
 
-const STYLES_H4= css`
+const STYLES_H4 = css`
   box-sizing: border-box;
   font-size: ${Constants.typescale.lvl1};
   line-height: 1.1;
@@ -125,14 +115,11 @@ const STYLES_H4= css`
 `;
 
 export const H4 = (props) => {
-  if (props.href) {
-    return <a css={STYLES_H4} {...props} />;
-  }
-
-  return <h4 css={STYLES_H4} {...props} />;
+  return <h4 css={css`${STYLES_H4};${ANCHOR};`} {...props} />;
 };
 
 const STYLES_P = css`
+
   box-sizing: border-box;
   font-family: ${Constants.font.text};
   font-size: ${Constants.typescale.lvl1};
@@ -142,15 +129,11 @@ const STYLES_P = css`
     font-family: ${Constants.font.semiBold};
     font-weight: 400;
   }
-
-  a {
-    font-family: ${Constants.font.semiBold};
-    font-weight: 400;
-  }
-`;
+  
+` ;
 
 export const P = (props) => {
-  return <div css={STYLES_P} {...props} />;
+  return <div css={css`${STYLES_P};${ANCHOR};`} {...props}></div>;
 };
 
 const STYLES_UL = css`
@@ -159,7 +142,7 @@ const STYLES_UL = css`
 `;
 
 export const UL = (props) => {
-  return <ul css={STYLES_UL} {...props} />;
+  return <ul css={css`${STYLES_UL};${ANCHOR};`} {...props} />;
 };
 
 const STYLES_OL = css`
@@ -168,7 +151,7 @@ const STYLES_OL = css`
 `;
 
 export const OL = (props) => {
-  return <ol css={STYLES_OL} {...props} />;
+  return <ol css={css`${STYLES_OL};${ANCHOR};`} {...props} />;
 };
 
 const STYLES_LI = css`
@@ -180,12 +163,23 @@ const STYLES_LI = css`
     font-weight: 400;
   }
 
-  a {
-    font-family: ${Constants.font.semiBold};
-    font-weight: 400;
-  }
 `;
 
 export const LI = (props) => {
-  return <li css={STYLES_LI} {...props} />;
+  return <li css={css`${STYLES_LI};${ANCHOR};`} {...props} />;
 };
+
+const ANCHOR = css`
+  a {
+    font-family: ${Constants.font.text};
+    font-weight: 400;
+    text-decoration: none;
+    color: ${Constants.system.link};
+  }
+
+  a:hover {
+    text-decoration: underline;
+    color: ${Constants.system.link};
+
+  }
+`;

--- a/pages/system/colors.js
+++ b/pages/system/colors.js
@@ -75,6 +75,8 @@ export default class SystemPageColors extends React.Component {
 
 {Constants.system.brand};
 
+{Constants.system.link};
+
 {Constants.system.green};
 
 {Constants.system.yellow};


### PR DESCRIPTION
Here's my proposed changes to add better link styles. 

I read the @emotion docs about [style composition](https://emotion.sh/docs/composition), but had an error`Attempted import error: '@emotion/css' does not contain a default export (imported as '_css').` when trying to combine styles. 

I put in a quick fix that looks like ` return <h1 css={css`${STYLES_H1};${ANCHOR};`} {...props} />;` 