### PR TITLE
Analytics API integration

### DIFF
--- a/node_common/constants.js
+++ b/node_common/constants.js
@@ -2,6 +2,7 @@ export const POLLING_RATE = 5000;
 export const POWERGATE_HOST = "https://grpcweb.slate.textile.io";
 export const FILE_STORAGE_URL = "./public/static/files/";
 export const GITHUB_URL = "https://github.com/filecoin-project/slate";
+export const ANALYTICS_URL = "https://slate-stats-dev.azurewebsites.net/";
 
 // NOTE(jim): 1 GB from Ignacio
 export const TEXTILE_ACCOUNT_BYTE_LIMIT = 1073741824;

--- a/node_common/managers/analytics.js
+++ b/node_common/managers/analytics.js
@@ -4,8 +4,11 @@ import * as Powergate from "~/node_common/powergate";
 import * as Constants from "~/node_common/constants";
 
 export const get = async () => {
-  const analytics = {};
-
+  // Current endpoints available for consumption
+  // Endpoints: blocks, blockParents, blockRewards, blockMessages, receipts, messages
+  const endpoint = "blocks";
+  const response = await fetch(Constants.ANALYTICS_URL + endpoint);
+  const analytics = response.json();
   // TODO(colin): We can bind Analytics here on the server.
   return analytics;
 };

--- a/pages/_/index.js
+++ b/pages/_/index.js
@@ -10,6 +10,11 @@ export const getServerSideProps = async ({ query }) => {
 
 export default class ApplicationPage extends React.Component {
   render() {
-    return <Application viewer={this.props.viewer} analytics={this.props.analytics} />;
+    return (
+      <Application
+        viewer={this.props.viewer}
+        analytics={this.props.analytics}
+      />
+    );
   }
 }


### PR DESCRIPTION
There are 6 endpoints that return meaningful data: blocks, blockParents, blockRewards, blockMessages, receipts, message.

API Project: https://github.com/filecoin-project/slate-stats
Example API call: https://slate-stats-dev.azurewebsites.net/blocks

All endpoints are returning 100 rows at the moment to preserve data, we can add pagination as needed (I think 100 rows per page sounds like a reasonable amount of data). 