### PR TITLE
New previews with title

### DIFF
--- a/common/svg.js
+++ b/common/svg.js
@@ -643,3 +643,95 @@ export const Refresh = (props) => (
     <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
   </svg>
 );
+
+export const Document = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height={props.height}
+    style={props.style}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M13 2H6C5.46957 2 4.96086 2.21071 4.58579 2.58579C4.21071 2.96086 4 3.46957 4 4V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V9L13 2Z" />
+    <path d="M13 2V9H20" />
+  </svg>
+);
+
+export const Book = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height={props.height}
+    style={props.style}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M4 19.5C4 18.837 4.26339 18.2011 4.73223 17.7322C5.20107 17.2634 5.83696 17 6.5 17H20" />
+    <path d="M6.5 2H20V22H6.5C5.83696 22 5.20107 21.7366 4.73223 21.2678C4.26339 20.7989 4 20.163 4 19.5V4.5C4 3.83696 4.26339 3.20107 4.73223 2.73223C5.20107 2.26339 5.83696 2 6.5 2V2Z" />
+  </svg>
+);
+
+export const Music = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height={props.height}
+    style={props.style}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M9 18V5L21 3V16" />
+    <path d="M6 21C7.65685 21 9 19.6569 9 18C9 16.3431 7.65685 15 6 15C4.34315 15 3 16.3431 3 18C3 19.6569 4.34315 21 6 21Z" />
+    <path d="M18 19C19.6569 19 21 17.6569 21 16C21 14.3431 19.6569 13 18 13C16.3431 13 15 14.3431 15 16C15 17.6569 16.3431 19 18 19Z" />
+  </svg>
+);
+
+export const Video = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height={props.height}
+    style={props.style}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M19.82 2H4.18C2.97602 2 2 2.97602 2 4.18V19.82C2 21.024 2.97602 22 4.18 22H19.82C21.024 22 22 21.024 22 19.82V4.18C22 2.97602 21.024 2 19.82 2Z" />
+    <path d="M7 2V22" />
+    <path d="M17 2V22" />
+    <path d="M2 12H22" />
+    <path d="M2 7H7" />
+    <path d="M2 17H7" />
+    <path d="M17 17H22" />
+    <path d="M17 7H22" />
+  </svg>
+);
+
+export const NoImage = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height={props.height}
+    style={props.style}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M1 1L23 23" />
+    <path d="M15.28 15.28C14.9481 15.765 14.5134 16.171 14.0068 16.469C13.5002 16.7669 12.9342 16.9496 12.3489 17.004C11.7637 17.0584 11.1737 16.9831 10.6209 16.7836C10.0681 16.5841 9.56601 16.2652 9.15042 15.8496C8.73483 15.434 8.41593 14.9319 8.2164 14.3791C8.01688 13.8263 7.94163 13.2363 7.99601 12.6511C8.05039 12.0658 8.23306 11.4998 8.53103 10.9932C8.829 10.4866 9.23495 10.0519 9.72 9.72M21 21H3C2.46957 21 1.96086 20.7893 1.58579 20.4142C1.21071 20.0391 1 19.5304 1 19V8C1 7.46957 1.21071 6.96086 1.58579 6.58579C1.96086 6.21071 2.46957 6 3 6H6L21 21ZM9 3H15L17 6H21C21.5304 6 22.0391 6.21071 22.4142 6.58579C22.7893 6.96086 23 7.46957 23 8V17.34L9 3Z" />
+  </svg>
+);

--- a/components/core/SearchModal.js
+++ b/components/core/SearchModal.js
@@ -100,6 +100,12 @@ const STYLES_LINK_HOVER = css`
   }
 `;
 
+const STYLES_TITLE = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
 const SlateEntry = ({ item }) => {
   return (
     <div css={STYLES_ENTRY}>
@@ -107,8 +113,10 @@ const SlateEntry = ({ item }) => {
         <div css={STYLES_ICON_CIRCLE}>
           <SVG.Slate2 height="16px" />
         </div>
-        <strong>{item.data.name}</strong>
-        <div>@{item.owner.username}</div>
+        <div css={STYLES_TITLE}>{item.data.name}</div>
+        {item.owner && item.owner.username ? (
+          <div>@{item.owner.username}</div>
+        ) : null}
       </div>
       {item.data.objects.length ? (
         <div css={STYLES_SLATE_IMAGES_CONTAINER}>
@@ -121,6 +129,7 @@ const SlateEntry = ({ item }) => {
             }}
             previewStyle={{ fontSize: "12px", padding: "4px" }}
             slate={item}
+            small
           />
         </div>
       ) : null}
@@ -135,14 +144,18 @@ const FileEntry = ({ item }) => {
         <div css={STYLES_ICON_CIRCLE}>
           <SVG.Folder2 height="16px" />
         </div>
-        <strong>{item.data.file.title || item.data.file.name}</strong>
-        <div css={STYLES_LINK_HOVER}>@{item.data.slate.owner.username}</div>
+        <div css={STYLES_TITLE}>
+          {item.data.file.title || item.data.file.name}
+        </div>
+        {item.data.slate.owner && item.data.slate.owner.username ? (
+          <div>@{item.data.slate.owner.username}</div>
+        ) : null}
       </div>
       <div css={STYLES_SLATE_IMAGE}>
         <SlateMediaObjectPreview
           style={{ fontSize: "12px", padding: "4px" }}
           url={item.data.file.url}
-          type={item.type}
+          type={item.data.file.type}
         />
       </div>
     </div>
@@ -210,6 +223,8 @@ export class SearchModal extends React.Component {
       this.miniSearch.addAll(response.data.users);
       this.miniSearch.addAll(response.data.slates);
       this.miniSearch.addAll(files);
+      console.log(response.data.slates);
+      console.log(files);
     }
   };
 
@@ -254,9 +269,11 @@ export class SearchModal extends React.Component {
 
   _handleSelect = async (value) => {
     if (value.type === "SLATE") {
-      value.data.owner = this.users.filter((user) => {
-        return user.username === value.data.owner.username;
-      })[0]; //TODO: slightly hacky way of getting the data. May want to serialize later?
+      if (value.data.owner && value.data.owner.username) {
+        value.data.owner = this.users.filter((user) => {
+          return user.username === value.data.owner.username;
+        })[0];
+      } //TODO: slightly hacky way of getting the data. May want to serialize later?
       this.props.onAction({
         type: "NAVIGATE",
         value: "V1_NAVIGATION_SLATE",
@@ -272,9 +289,11 @@ export class SearchModal extends React.Component {
     }
     if (value.type === "FILE") {
       let slate = value.data.data.slate;
-      slate.owner = this.users.filter((user) => {
-        return user.username === slate.owner.username;
-      })[0]; //TODO: slightly hacky way of getting the data. May want to serialize later?
+      if (slate.owner && slate.owner.username) {
+        slate.owner = this.users.filter((user) => {
+          return user.username === slate.owner.username;
+        })[0];
+      } //TODO: slightly hacky way of getting the data. May want to serialize later?
       this.props.onAction({
         type: "NAVIGATE",
         value: "V1_NAVIGATION_SLATE",

--- a/components/core/Slate.js
+++ b/components/core/Slate.js
@@ -180,7 +180,11 @@ export default class Slate extends React.Component {
 
       return (
         <div key={index} css={STYLES_ITEM}>
-          <SlateMediaObjectPreview type={data.type} url={data.url} />
+          <SlateMediaObjectPreview
+            type={data.type}
+            url={data.url}
+            title={data.title || data.name}
+          />
           <figure css={STYLES_BUTTON}>
             <CircleButtonGray
               style={{ marginRight: 16 }}

--- a/components/core/SlateMediaObjectPreview.js
+++ b/components/core/SlateMediaObjectPreview.js
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as Constants from "~/common/constants";
+import * as SVG from "~/common/svg";
 
 import { css } from "@emotion/react";
 
@@ -18,10 +19,23 @@ const STYLES_ENTITY = css`
   background-color: ${Constants.system.foreground};
   font-size: 24px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   pointer-events: none;
+  padding: 8px;
+  font-size: 16px;
+`;
+
+const STYLES_TITLE = css`
+  width: 100%;
+  text-align: center;
+  margin-top: 8px;
+  overflow: hidden;
+  word-break: break-all;
+  ${"" /* text-overflow: ellipsis;
+  white-space: nowrap; */}
 `;
 
 export default class SlateMediaObjectPreview extends React.Component {
@@ -29,17 +43,31 @@ export default class SlateMediaObjectPreview extends React.Component {
     // NOTE(jim):
     // This is a hack to catch this undefined case I don't want to track down yet.
     const url = this.props.url.replace("https://undefined", "https://");
+    const title =
+      this.props.title && this.props.title.length > 30
+        ? this.props.title.substring(0, 30) + "..."
+        : this.props.title;
 
     let element = (
       <article css={STYLES_ENTITY} style={this.props.style}>
-        No Preview
+        <div>
+          <SVG.NoImage height="24px" />
+        </div>
+        {this.props.title && !this.props.small ? (
+          <div css={STYLES_TITLE}>{title}</div>
+        ) : null}
       </article>
     );
 
     if (this.props.type && this.props.type.startsWith("video/")) {
       element = (
         <article css={STYLES_ENTITY} style={this.props.style}>
-          Video
+          <div>
+            <SVG.Video height="24px" />
+          </div>
+          {this.props.title && !this.props.small ? (
+            <div css={STYLES_TITLE}>{title}</div>
+          ) : null}
         </article>
       );
     }
@@ -47,7 +75,12 @@ export default class SlateMediaObjectPreview extends React.Component {
     if (this.props.type && this.props.type.startsWith("audio/")) {
       element = (
         <article css={STYLES_ENTITY} style={this.props.style}>
-          Audio
+          <div>
+            <SVG.Music height="24px" />
+          </div>
+          {this.props.title && !this.props.small ? (
+            <div css={STYLES_TITLE}>{title}</div>
+          ) : null}
         </article>
       );
     }
@@ -55,7 +88,12 @@ export default class SlateMediaObjectPreview extends React.Component {
     if (this.props.type && this.props.type.startsWith("application/epub")) {
       element = (
         <article css={STYLES_ENTITY} style={this.props.style}>
-          EPub
+          <div>
+            <SVG.Book height="24px" />
+          </div>
+          {this.props.title && !this.props.small ? (
+            <div css={STYLES_TITLE}>{title}</div>
+          ) : null}
         </article>
       );
     }
@@ -63,7 +101,12 @@ export default class SlateMediaObjectPreview extends React.Component {
     if (this.props.type && this.props.type.startsWith("application/pdf")) {
       element = (
         <article css={STYLES_ENTITY} style={this.props.style}>
-          PDF
+          <div>
+            <SVG.Document height="24px" />
+          </div>
+          {this.props.title && !this.props.small ? (
+            <div css={STYLES_TITLE}>{title}</div>
+          ) : null}
         </article>
       );
     }

--- a/components/core/SlatePreviewBlock.js
+++ b/components/core/SlatePreviewBlock.js
@@ -42,6 +42,8 @@ export function SlatePreviewRow(props) {
             type={each.type}
             url={each.url}
             style={props.previewStyle}
+            title={each.title || each.name}
+            small={props.small}
           />
         </div>
       ))}


### PR DESCRIPTION
Non-image previews now show the name of the file and icon for the file type, rather than just the file type or "no preview".

Also fixed small bug that didn't handle serialization well when it came to the search modal (would error if there was no user provided for the slate)

![image](https://user-images.githubusercontent.com/33686587/91777395-8bbffb00-eba4-11ea-9175-fe7b0cdc3f09.png)

![image](https://user-images.githubusercontent.com/33686587/91777414-97132680-eba4-11ea-94e2-0bada7f38f75.png)

