### PR TITLE
fix: deeplink slate query bug

### DIFF
--- a/pages/api/search/slates/[query].js
+++ b/pages/api/search/slates/[query].js
@@ -15,7 +15,7 @@ export default async (req, res) => {
 
   if (req.body.data.deeplink) {
     if (slates.length) {
-      const slate = { ...slates[0] };
+      const slate = slates.filter((item) => item.slatename === query)[0];
       const user = await Data.getUserById({ id: slate.data.ownerId });
       slate.user = Serializers.user(user);
 


### PR DESCRIPTION
This PR fixes issue #281.

Previously, if a user create a slate (e.g. `cyber`) which has a name similar to the name of another slate (e.g. `cybernetics`), the query returns all of them and selects the first one. 

This PR ensures that the name of deeplink query is the one actually returned. 