### PR TITLE
Better handling for slate name taken

### DIFF
--- a/common/messages.js
+++ b/common/messages.js
@@ -66,6 +66,8 @@ export const error = {
   SERVER_UPDATE_SLATE_MUST_PROVIDE_NAME: "Please provide a slate name",
   SERVER_UPDATE_SLATE:
     "We're having trouble updating that slate right now. Please try again later",
+  SERVER_UPDATE_SLATE_NAME_TAKEN:
+    "It looks like that slatename is taken. Please choose another",
   V1_SERVER_UPLOAD_SLATE_NOT_FOUND:
     "We're having trouble locating that slate right now. Please try again later",
   V1_SERVER_API_KEY_NOT_FOUND:

--- a/pages/api/slates/update.js
+++ b/pages/api/slates/update.js
@@ -56,6 +56,16 @@ export default async (req, res) => {
     });
   }
 
+  const existingSlate = await Data.getSlateByName({
+    slatename: req.body.data.data.name,
+  });
+  if (existingSlate) {
+    return res.status(500).send({
+      decorator: "SERVER_UPDATE_SLATE_NAME_TAKEN",
+      error: true,
+    });
+  }
+
   const slate = await Data.updateSlateById({
     id: response.id,
     slatename: Strings.createSlug(req.body.data.data.name),


### PR DESCRIPTION
Currently it's just a generic error of "we can't update that right now" when someone tries to rename thier slate to a name that is taken. Now it'll be this error:

![image](https://user-images.githubusercontent.com/33686587/93688360-198f5780-fa7a-11ea-8fb4-96807d5b869c.png)
