### PR TITLE
Fixed carousel bug

### DIFF
--- a/components/core/DataView.js
+++ b/components/core/DataView.js
@@ -617,7 +617,9 @@ export default class DataView extends React.Component {
                 <div
                   key={each.id}
                   css={STYLES_IMAGE_BOX}
-                  onClick={() => this._handleSelect(index)}
+                  onClick={() =>
+                    this._handleSelect(index + this.state.startIndex)
+                  }
                 >
                   <SlateMediaObjectPreview
                     url={`${Constants.gateways.ipfs}/${each.ipfs.replace(


### PR DESCRIPTION
Carousel on data view page was always showing the first 20 images only, regardless of which page you were on. Now fixed