### PR TITLE
Reproduced ERR_CONNECTION_RESET - Finally able to reproduce the bug with Buckets by throttling my Stream.

### DIFF
--- a/node_common/upload.js
+++ b/node_common/upload.js
@@ -7,6 +7,7 @@ import * as Logs from "~/node_common/script-logging";
 import AbortController from "abort-controller";
 import BusBoyConstructor from "busboy";
 import Queue from "p-queue";
+import Throttle from "~/node_common/vendor/throttle";
 
 const WORKER_NAME = "BROWSER->RENDER->TEXTILE";
 const HIGH_WATER_MARK = 1024 * 1024 * 3;
@@ -166,7 +167,9 @@ export async function formMultipart(req, res, { user, bucketName }) {
       });
 
       Logs.task("req.pipe(writableStream)", WORKER_NAME);
-      req.pipe(writableStream);
+      req
+        .pipe(new Throttle({ bytes: HIGH_WATER_MARK, interval: 1000 }))
+        .pipe(writableStream);
     });
   };
 

--- a/node_common/vendor/throttle.js
+++ b/node_common/vendor/throttle.js
@@ -1,0 +1,55 @@
+const { Transform } = require("stream");
+
+/**
+ * Transform stream with throttle functionality
+ *
+ * @class
+ * @extends Transform
+ * @param {Object} options - Configuration options
+ * @param {Integer} options.bytes - Number of bytes to send in one chunk
+ * @param {Integer} options.interval - Interval for sending chunks, in miliseconds
+ */
+export default class Throttle extends Transform {
+  constructor(options) {
+    super();
+    Object.assign(this, options);
+    this.previousPassTime = Date.now();
+    this.queue = [];
+    this.intervalId = this.setPushInterval();
+  }
+
+  _transform(chunks, _, cb) {
+    for (const chunk of chunks) {
+      this.queue.push(chunk);
+    }
+    this.isQueueFull() ? setTimeout(cb, this.interval) : cb();
+  }
+
+  _flush(cb) {
+    clearInterval(this.intervalId);
+    this.intervalId = this.setPushInterval(cb);
+  }
+
+  setPushInterval(cb = null) {
+    return setInterval(() => {
+      const elapsedTime = Date.now() - this.previousPassTime;
+      if (elapsedTime < this.interval) return;
+
+      if (this.queue.length > 0) {
+        this.push(this.getChunk());
+        return (this.previousPassTime += elapsedTime);
+      }
+
+      clearInterval(this.intervalId);
+      return cb && cb();
+    }, this.interval / 10);
+  }
+
+  getChunk() {
+    return Buffer.from(this.queue.splice(0, this.bytes));
+  }
+
+  isQueueFull() {
+    return this.queue.length >= 2 * this.bytes;
+  }
+}


### PR DESCRIPTION
In this PR, you will be able to clone and run locally and reproduce

* Bucket bricking
* Attempted solution for backpressuring in NodeJS

# Introduction

I noticed something really interesting as I was piping my `WritableStream` into a `ReadableStream` on production after adding `progress` thanks to @carsonfarmer's suggestion.

<img width="1469" alt="Screen Shot 2020-10-09 at 10 35 07 PM" src="https://user-images.githubusercontent.com/310223/95647642-f3137980-0a85-11eb-93f8-31f20b9ee51a.png">

* Almost every single time my file upload in production/local would complete to node memory way faster than `buckets.pushPath`, in fact in this example you can see that I had already completed 4GB of transfer before 370MB has been actually pushed to Textile buckets.

## So I had an idea

What if I throttled the connection so they would be at the exact same speed?

<img width="1524" alt="Screen Shot 2020-10-09 at 11 06 06 PM" src="https://user-images.githubusercontent.com/310223/95647670-2f46da00-0a86-11eb-95c5-9b2c713d010d.png">

* Eureka! This felt right, they are now operating side by side.

However, trouble in paradise:

<img width="1466" alt="Screen Shot 2020-10-09 at 11 08 56 PM" src="https://user-images.githubusercontent.com/310223/95647688-54d3e380-0a86-11eb-8aca-cfe044b12b06.png">

And another:

<img width="769" alt="Screen Shot 2020-10-09 at 11 18 08 PM" src="https://user-images.githubusercontent.com/310223/95647709-7765fc80-0a86-11eb-9cd3-0905213cb1f4.png">

* I hope this is something about rate limiting or data transfer speed
* This produces a bricked bucket every single time.

I feel like this gets us closer to what the issue is with streaming data for large files. This reproduces the bug I've been experiencing locally without having to go to production so I hope it helps us test :)