### PR TITLE
dividing line left of UserControls dropdown arrow

### DIFF
--- a/components/core/ApplicationUserControls.js
+++ b/components/core/ApplicationUserControls.js
@@ -107,7 +107,7 @@ const STYLES_ITEM_BOX = css`
   justify-content: center;
   height: 100%;
   padding: 8px;
-  padding-right: 12px;
+  padding-right: 9px;
   transition: 200ms ease all;
   border-left: 2px solid ${Constants.system.foreground};
 

--- a/components/core/ApplicationUserControls.js
+++ b/components/core/ApplicationUserControls.js
@@ -98,6 +98,7 @@ const STYLES_ITEM_BOX_MOBILE = css`
   background-color: ${Constants.system.white};
   cursor: pointer;
   border-radius: 4px;
+  border-left: 2px solid ${Constants.system.foreground};
 `;
 
 const STYLES_ITEM_BOX = css`
@@ -108,6 +109,8 @@ const STYLES_ITEM_BOX = css`
   padding: 8px;
   padding-right: 12px;
   transition: 200ms ease all;
+  border-left: 2px solid ${Constants.system.foreground};
+
 
   :hover {
     color: ${Constants.system.brand};


### PR DESCRIPTION
Added a border left of the user control dropdown arrow and moved the arrow a bit to the right to center it better on desktop
