### PR TITLE
fixing long string styling issue

### DIFF
--- a/pages/_/slate.js
+++ b/pages/_/slate.js
@@ -30,6 +30,7 @@ const STYLES_SLATE_INTRO = css`
   margin: 0 64px;
   align-items: baseline;
   line-height: 1.3;
+  word-wrap: break-word;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     margin: 0 24px;
@@ -58,6 +59,7 @@ const STYLES_DESCTIPTION = css`
   font-family: ${Constants.font.text};
   width: 50%;
   color: ${Constants.system.black};
+  word-wrap: break-word;
 
   @media (max-width: ${Constants.sizes.tablet}px) {
     width: 100%;
@@ -75,7 +77,9 @@ const STYLES_TITLE = css`
   font-weight: 400;
   color: ${Constants.system.black};
   width: auto;
+  max-width: 100%;
   margin-right: 24px;
+  word-wrap: break-word;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     font-size: ${Constants.typescale.lvl2};


### PR DESCRIPTION
patching a styling issue that @martinalong pointed out
![image](https://user-images.githubusercontent.com/35607644/97229478-ade58c00-1795-11eb-9c6a-4a800bb12d8c.png)

it's now fixed:
<img width="1792" alt="Screen Shot 2020-10-26 at 2 16 17 PM" src="https://user-images.githubusercontent.com/35607644/97229587-d2416880-1795-11eb-8c88-39e78ecd6b29.png">
