### PR TITLE
empty profile view

### DIFF
--- a/common/actions.js
+++ b/common/actions.js
@@ -86,6 +86,13 @@ export const getSlateById = async (data) => {
   });
 };
 
+export const getSlatesByIds = async (data) => {
+  return await returnJSON(`/api/slates/get`, {
+    ...DEFAULT_OPTIONS,
+    body: JSON.stringify({ data }),
+  });
+};
+
 export const deleteTrustRelationship = async (data) => {
   return await returnJSON(`/api/users/trust-delete`, {
     ...DEFAULT_OPTIONS,

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -198,6 +198,7 @@ export default class Profile extends React.Component {
     let response5 = await Actions.getSlateById({ id: "81fa0b39-0e96-4c7f-8587-38468bb67cb3" });
     let response6 = await Actions.getSlateById({ id: "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29" });
 
+    // @TARA: actual slate content to swap out when pushing to prod.
     // let response1 = await Actions.getSlateById({ id: "d2861ac4-fc41-4c07-8f21-d0bf06be364c" });
     // let response2 = await Actions.getSlateById({ id: "9c2c458c-d92a-4e81-a4b6-bf6ab4607470" });
     // let response3 = await Actions.getSlateById({ id: "7f461144-0647-43d7-8294-788b37ae5979" });

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Constants from "~/common/constants";
 import * as Strings from "~/common/strings";
+import * as Actions from "~/common/actions";
 
 import { css } from "@emotion/core";
 import { ProcessedText } from "~/components/system/components/Typography";
@@ -98,8 +99,7 @@ const STYLES_NAME = css`
   font-family: ${Constants.font.medium};
   max-width: 100%;
   font-weight: 400;
-  margin-top: 8px;
-  margin-right: 24px;
+  margin: 8px 24px 8px 0;
   overflow-wrap: break-word;
   white-space: pre-wrap;
 
@@ -175,15 +175,54 @@ const STYLES_FLEX = css`
   }
 `;
 
+const STYLES_EXPLORE = css`
+  padding-top: 8px;
+  margin: 200px auto 24px auto;
+  font-size: ${Constants.typescale.lvl2};
+  font-family: ${Constants.font.medium};
+  font-weight: 400;
+  color: ${Constants.system.black};
+`;
+
 export default class Profile extends React.Component {
+  state = {
+    exploreSlates: [],
+  };
+
+  componentDidMount = async () => {
+    let exploreSlates = [];
+    let response1 = await Actions.getSlateById({ id: "857ad84d-7eff-4861-a988-65c84b62fc23" });
+    let response2 = await Actions.getSlateById({ id: "81fa0b39-0e96-4c7f-8587-38468bb67cb3" });
+    let response3 = await Actions.getSlateById({ id: "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29" });
+    let response4 = await Actions.getSlateById({ id: "857ad84d-7eff-4861-a988-65c84b62fc23" });
+    let response5 = await Actions.getSlateById({ id: "81fa0b39-0e96-4c7f-8587-38468bb67cb3" });
+    let response6 = await Actions.getSlateById({ id: "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29" });
+
+    // let response1 = await Actions.getSlateById({ id: "d2861ac4-fc41-4c07-8f21-d0bf06be364c" });
+    // let response2 = await Actions.getSlateById({ id: "9c2c458c-d92a-4e81-a4b6-bf6ab4607470" });
+    // let response3 = await Actions.getSlateById({ id: "7f461144-0647-43d7-8294-788b37ae5979" });
+    // let response4 = await Actions.getSlateById({ id: "f72c2594-b8ac-41f6-91e0-b2da6788ae23" });
+    // let response5 = await Actions.getSlateById({ id: "a0d6e2f2-564d-47ed-bf56-13c42634703d" });
+    // let response6 = await Actions.getSlateById({ id: "0ba92c73-92e7-4b00-900e-afae4856c9ea" });
+    exploreSlates.push(
+      response1.slate,
+      response2.slate,
+      response3.slate,
+      response4.slate,
+      response5.slate,
+      response6.slate
+    );
+    this.setState({ exploreSlates });
+  };
+
   render() {
     let data = this.props.creator ? this.props.creator : this.props.data;
+    console.log(this.state.exploreSlates);
 
     let total = 0;
     for (let slate of data.slates) {
       total += slate.data.objects.length;
     }
-
     return (
       <div>
         {this.props.onAction ? (
@@ -252,7 +291,6 @@ export default class Profile extends React.Component {
             </div>
           </div>
         )}
-
         {this.props.onAction ? (
           <div css={STYLES_PROFILE_INTERNAL} style={{ paddingTop: 0 }}>
             {data.slates && data.slates.length ? (
@@ -274,7 +312,16 @@ export default class Profile extends React.Component {
                 username={data.username}
                 onAction={this.props.onAction}
               />
-            ) : null}
+            ) : (
+              <div>
+                {" "}
+                <p style={{ color: `${Constants.system.darkGray}` }}>
+                  No publicly shared slates from @{data.username}.
+                </p>
+                <div css={STYLES_EXPLORE}>Explore slates</div>
+                <SlatePreviewBlocksExternal slates={this.state.exploreSlates} />
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -85,7 +85,7 @@ const STYLES_PROFILE_IMAGE = css`
   height: 80px;
   flex-shrink: 0;
   border-radius: 4px;
-  margin-right: 24px;
+  margin: 8px 24px 0 0;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     width: 64px;
@@ -95,13 +95,25 @@ const STYLES_PROFILE_IMAGE = css`
 `;
 
 const STYLES_NAME = css`
-  font-size: ${Constants.typescale.lvl4};
+  font-size: ${Constants.typescale.lvl3};
   font-family: ${Constants.font.medium};
   max-width: 100%;
   font-weight: 400;
-  margin: 8px 24px 8px 0;
+  margin: 8px 24px 0px 0;
   overflow-wrap: break-word;
   white-space: pre-wrap;
+  color: ${Constants.system.black};
+`;
+
+const STYLES_NAME_INTERNAL = css`
+  font-size: ${Constants.typescale.lvl3};
+  font-family: ${Constants.font.semiBold};
+  max-width: 100%;
+  font-weight: 400;
+  margin: 8px 24px 0px 0;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+  color: ${Constants.system.black};
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     margin-bottom: 8px;
@@ -109,18 +121,9 @@ const STYLES_NAME = css`
   }
 `;
 
-const STYLES_NAME_INTERNAL = css`
-  font-size: ${Constants.typescale.lvl3};
-  font-family: ${Constants.font.medium};
-  font-weight: 400;
-  max-width: 100%;
-  margin-top: 8px;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
-`;
-
 const STYLES_DESCRIPTION = css`
-  font-size: ${Constants.typescale.lvl1};
+  font-size: ${Constants.typescale.lvl0};
+  color: ${Constants.system.darkGray};
   width: 100%;
   overflow-wrap: break-word;
   white-space: pre-wrap;
@@ -131,57 +134,53 @@ const STYLES_DESCRIPTION = css`
 
 const STYLES_STATS = css`
   font-size: ${Constants.typescale.lvl0};
-  line-height: 1.5;
-  margin: 12px 0 24px 0;
+  margin: 16px 0 16px 0;
   display: flex;
   width: 100%;
-  flex-wrap: wrap;
+  color: ${Constants.system.grayBlack};
 `;
 
 const STYLES_STAT = css`
-  margin-right: 16px;
+  margin-right: 8px;
   width: 112px;
   flex-shrink: 0;
 `;
 
 const STYLES_BUTTON = css`
-  padding: 10px 24px;
+  width: 96px;
+  height: 36px;
+  border-radius: 4px;
+  border: 1px solid ${Constants.system.gray};
+  padding: 8px 16px;
   cursor: pointer;
-  font-family: ${Constants.font.semiBold};
+  margin-top: 8px;
+  font-family: ${Constants.font.medium};
   font-weight: 400;
   font-size: 14px;
   text-align: center;
   text-decoration: none;
-  height: 40px;
-  width: 160px;
-  border-radius: 4px;
-  color: ${Constants.system.white};
-  background-color: ${Constants.system.brand};
+  color: ${Constants.system.black};
 
+  :hover {
+    background-color: ${Constants.system.gray};
+    transition: 200ms background-color linear;
+  }
   :visited {
-    color: ${Constants.system.white};
+    color: ${Constants.system.black};
   }
 `;
 
 const STYLES_FLEX = css`
   display: flex;
-  margin-bottom: 12px;
-  align-items: baseline;
-  justify-content: space-between;
+  align-items: center;
   flex-wrap: wrap;
-
-  @media (max-width: ${Constants.sizes.tablet}px) {
-    display: block;
-  }
 `;
 
 const STYLES_EXPLORE = css`
-  padding-top: 8px;
-  margin: 200px auto 24px auto;
-  font-size: ${Constants.typescale.lvl2};
-  font-family: ${Constants.font.medium};
-  font-weight: 400;
-  color: ${Constants.system.black};
+  margin: 160px auto 64px auto;
+  height: 1px;
+  width: 80px;
+  background-color: ${Constants.system.gray};
 `;
 
 export default class Profile extends React.Component {
@@ -189,36 +188,9 @@ export default class Profile extends React.Component {
     exploreSlates: [],
   };
 
-  componentDidMount = async () => {
-    let exploreSlates = [];
-    let response1 = await Actions.getSlateById({ id: "857ad84d-7eff-4861-a988-65c84b62fc23" });
-    let response2 = await Actions.getSlateById({ id: "81fa0b39-0e96-4c7f-8587-38468bb67cb3" });
-    let response3 = await Actions.getSlateById({ id: "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29" });
-    let response4 = await Actions.getSlateById({ id: "857ad84d-7eff-4861-a988-65c84b62fc23" });
-    let response5 = await Actions.getSlateById({ id: "81fa0b39-0e96-4c7f-8587-38468bb67cb3" });
-    let response6 = await Actions.getSlateById({ id: "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29" });
-
-    // @TARA: actual slate content to swap out when pushing to prod.
-    // let response1 = await Actions.getSlateById({ id: "d2861ac4-fc41-4c07-8f21-d0bf06be364c" });
-    // let response2 = await Actions.getSlateById({ id: "9c2c458c-d92a-4e81-a4b6-bf6ab4607470" });
-    // let response3 = await Actions.getSlateById({ id: "7f461144-0647-43d7-8294-788b37ae5979" });
-    // let response4 = await Actions.getSlateById({ id: "f72c2594-b8ac-41f6-91e0-b2da6788ae23" });
-    // let response5 = await Actions.getSlateById({ id: "a0d6e2f2-564d-47ed-bf56-13c42634703d" });
-    // let response6 = await Actions.getSlateById({ id: "0ba92c73-92e7-4b00-900e-afae4856c9ea" });
-    exploreSlates.push(
-      response1.slate,
-      response2.slate,
-      response3.slate,
-      response4.slate,
-      response5.slate,
-      response6.slate
-    );
-    this.setState({ exploreSlates });
-  };
-
   render() {
     let data = this.props.creator ? this.props.creator : this.props.data;
-    console.log(this.state.exploreSlates);
+    let exploreSlates = this.props.exploreSlates;
 
     let total = 0;
     for (let slate of data.slates) {
@@ -239,15 +211,18 @@ export default class Profile extends React.Component {
               </div>
               <div css={STYLES_STATS}>
                 <div css={STYLES_STAT}>
-                  <div style={{ color: `${Constants.system.darkGray}` }}>Public data</div>
-                  <div style={{ fontFamily: `${Constants.font.medium}` }}>{total}</div>
+                  <div style={{ fontFamily: `${Constants.font.text}` }}>
+                    {total}{" "}
+                    <span style={{ color: `${Constants.system.darkGray}` }}>Public data</span>
+                  </div>
                 </div>
                 <div css={STYLES_STAT}>
-                  <div style={{ color: `${Constants.system.darkGray}` }}>Public slates</div>
-                  <div style={{ fontFamily: `${Constants.font.medium}` }}>{data.slates.length}</div>
+                  <div style={{ fontFamily: `${Constants.font.text}` }}>
+                    {data.slates.length}{" "}
+                    <span style={{ color: `${Constants.system.darkGray}` }}>Public slates</span>
+                  </div>
                 </div>
               </div>
-
               {data.data.body ? (
                 <div css={STYLES_DESCRIPTION}>
                   <ProcessedText text={data.data.body} />
@@ -265,24 +240,25 @@ export default class Profile extends React.Component {
               <div css={STYLES_INFO}>
                 <div css={STYLES_FLEX}>
                   <div css={STYLES_NAME}>{Strings.getPresentationName(data)}</div>
-                  <div css={STYLES_BUTTON}>
-                    <a css={STYLES_BUTTON} href={"http://slate.host/_"}>
-                      Follow
-                    </a>
-                  </div>
+                  <a css={STYLES_BUTTON} href={"http://slate.host/_"}>
+                    Follow
+                  </a>
                 </div>
                 <div css={STYLES_STATS}>
                   <div css={STYLES_STAT}>
-                    <div style={{ color: `${Constants.system.darkGray}` }}>Public data</div>
-                    <div style={{ fontFamily: `${Constants.font.medium}` }}>{total}</div>
+                    <div style={{ fontFamily: `${Constants.font.text}` }}>
+                      {total}{" "}
+                      <span style={{ color: `${Constants.system.darkGray}` }}>Public data</span>
+                    </div>
                   </div>
                   <div css={STYLES_STAT}>
-                    <div style={{ color: `${Constants.system.darkGray}` }}>Public slates</div>
-                    <div style={{ fontFamily: `${Constants.font.medium}` }}>
-                      {data.slates.length}
+                    <div style={{ fontFamily: `${Constants.font.text}` }}>
+                      {data.slates.length}{" "}
+                      <span style={{ color: `${Constants.system.darkGray}` }}>Public slates</span>
                     </div>
                   </div>
                 </div>
+
                 {data.data.body ? (
                   <div css={STYLES_DESCRIPTION} style={{ marginBottom: 16 }}>
                     <ProcessedText text={data.data.body} />
@@ -316,11 +292,11 @@ export default class Profile extends React.Component {
             ) : (
               <div>
                 {" "}
-                <p style={{ color: `${Constants.system.darkGray}` }}>
+                <p style={{ marginTop: 40, color: `${Constants.system.darkGray}` }}>
                   No publicly shared slates from @{data.username}.
                 </p>
-                <div css={STYLES_EXPLORE}>Explore slates</div>
-                <SlatePreviewBlocksExternal slates={this.state.exploreSlates} />
+                <div css={STYLES_EXPLORE} />
+                <SlatePreviewBlocksExternal slates={exploreSlates} />
               </div>
             )}
           </div>

--- a/components/core/SlatePreviewBlockExternal.js
+++ b/components/core/SlatePreviewBlockExternal.js
@@ -406,7 +406,7 @@ export default class SlatePreviewBlocksExternal extends React.Component {
   };
 
   render() {
-    console.log(this.props.slates, "22");
+    console.log("check slates", this.props.slates);
     return (
       <div css={STYLES_SLATES}>
         {this.props.slates.map((slate) => (

--- a/components/core/SlatePreviewBlockExternal.js
+++ b/components/core/SlatePreviewBlockExternal.js
@@ -335,7 +335,8 @@ const STYLES_LINK = css`
   color: ${Constants.system.black};
   text-decoration: none;
   width: calc(33.33% - 16px);
-  margin-bottom: 24px;
+  margin-bottom: 16px;
+  margin-right: 16px;
 
   @media (max-width: ${Constants.sizes.tablet}px) {
     width: 50%;
@@ -352,7 +353,6 @@ const STYLES_SLATES = css`
   flex-wrap: wrap;
   overflow: hidden;
   padding-bottom: 48px;
-  justify-content: space-between;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     display: block;

--- a/components/core/SlatePreviewBlockExternal.js
+++ b/components/core/SlatePreviewBlockExternal.js
@@ -103,7 +103,7 @@ export class SlatePreviewRow extends React.Component {
 const STYLES_BLOCK = css`
   box-shadow: 0 0 0 0.5px ${Constants.system.lightBorder} inset,
     0 0 40px 0 ${Constants.system.shadow};
-  padding: 16px;
+  padding: 24px;
   font-size: 12px;
   text-align: left;
   cursor: pointer;
@@ -127,10 +127,11 @@ const STYLES_TITLE_LINE = css`
 
 const STYLES_BODY = css`
   font-family: ${Constants.font.text};
-  font-size: ${Constants.typescale.lvl1};
+  font-size: ${Constants.typescale.lvl0};
   margin-bottom: 24px;
   white-space: pre-wrap;
   word-wrap: break-word;
+  color: ${Constants.system.darkGray};
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     display: none;
@@ -138,12 +139,12 @@ const STYLES_BODY = css`
 `;
 
 const STYLES_TITLE = css`
-  font-size: ${Constants.typescale.lvl2};
-  font-family: ${Constants.font.semiBold};
+  font-size: ${Constants.typescale.lvl1};
+  font-family: ${Constants.font.medium};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin: 16px 0 0 0;
+  margin: 16px 0 4px 0;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     font-size: ${Constants.typescale.lvl1};
@@ -156,13 +157,19 @@ const STYLES_PREVIEW = css`
 
 const STYLES_INFO = css`
   display: flex;
+  justify-content: space-between;
 `;
 
 const STYLES_OBJECT_COUNT = css`
   margin-top: 18px;
-  width: 15%;
-  font-size: ${Constants.typescale.lvl0};
+  width: auto;
+  font-size: ${Constants.typescale.lvlN1};
   color: ${Constants.system.darkGray};
+  margin-right: 0;
+
+  @media (max-width: ${Constants.sizes.mobile}px) {
+    margin-top: 18px;
+  }
 `;
 
 export class SlatePreviewBlock extends React.Component {
@@ -212,7 +219,6 @@ export class SlatePreviewBlock extends React.Component {
 
   render() {
     let first = this.props.slate.data.objects ? this.props.slate.data.objects[0] : null;
-    console.log(this.props.slate.data);
 
     return (
       <div css={STYLES_BLOCK}>
@@ -273,11 +279,8 @@ export class SlatePreviewBlock extends React.Component {
             />
           )}
           <div css={STYLES_INFO}>
-            <div css={STYLES_OBJECT_COUNT}>{this.props.slate.data.objects.length}</div>
             <div style={{ width: `85%` }}>
-              <div css={STYLES_TITLE_LINE}>
-                <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
-              </div>
+              <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
               {this.props.slate.data.body ? (
                 <div css={STYLES_BODY}>
                   <ViewAllButton noButton fullText={this.props.slate.data.body} maxCharacter={100}>
@@ -287,6 +290,10 @@ export class SlatePreviewBlock extends React.Component {
               ) : (
                 <div style={{ height: "8px" }} />
               )}
+            </div>
+            <div css={STYLES_OBJECT_COUNT}>
+              {this.props.slate.data.objects.length} file
+              {this.props.slate.data.objects.length > 1 ? "s" : ""}
             </div>
           </div>
         </span>
@@ -318,11 +325,21 @@ export class SlatePreviewBlock extends React.Component {
             )}
           </div>
           <div css={STYLES_INFO}>
-            <div css={STYLES_OBJECT_COUNT}>{this.props.slate.data.objects.length}</div>
             <div style={{ width: `85%` }}>
-              <div css={STYLES_TITLE_LINE}>
-                <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
-              </div>
+              <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
+              {this.props.slate.data.body ? (
+                <div css={STYLES_BODY}>
+                  <ViewAllButton noButton fullText={this.props.slate.data.body} maxCharacter={100}>
+                    <ProcessedText text={this.props.slate.data.body} />
+                  </ViewAllButton>
+                </div>
+              ) : (
+                <div style={{ height: "8px" }} />
+              )}
+            </div>
+            <div css={STYLES_OBJECT_COUNT}>
+              {this.props.slate.data.objects.length} file
+              {this.props.slate.data.objects.length > 1 ? "s" : ""}
             </div>
           </div>
         </span>
@@ -332,7 +349,7 @@ export class SlatePreviewBlock extends React.Component {
 }
 
 const STYLES_LINK = css`
-  color: ${Constants.system.black};
+  color: ${Constants.system.grayBlack};
   text-decoration: none;
   width: calc(33.33% - 16px);
   margin-bottom: 16px;
@@ -401,6 +418,7 @@ export default class SlatePreviewBlocksExternal extends React.Component {
   };
 
   render() {
+    console.log(this.props.slates, "22");
     return (
       <div css={STYLES_SLATES}>
         {this.props.slates.map((slate) => (

--- a/components/core/SlatePreviewBlockExternal.js
+++ b/components/core/SlatePreviewBlockExternal.js
@@ -107,7 +107,7 @@ const STYLES_BLOCK = css`
   font-size: 12px;
   text-align: left;
   cursor: pointer;
-  height: 480px;
+  height: 440px;
   width: 100%;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
@@ -116,22 +116,14 @@ const STYLES_BLOCK = css`
   }
 `;
 
-const STYLES_TITLE_LINE = css`
-  width: 100%;
-  display: flex;
-  align-items: center;
-  font-size: ${Constants.typescale.lvl1};
-  margin-bottom: 8px;
-  overflow-wrap: break-word;
-`;
-
 const STYLES_BODY = css`
   font-family: ${Constants.font.text};
   font-size: ${Constants.typescale.lvl0};
-  margin-bottom: 24px;
-  white-space: pre-wrap;
-  word-wrap: break-word;
   color: ${Constants.system.darkGray};
+  margin-bottom: 24px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     display: none;
@@ -283,9 +275,7 @@ export class SlatePreviewBlock extends React.Component {
               <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
               {this.props.slate.data.body ? (
                 <div css={STYLES_BODY}>
-                  <ViewAllButton noButton fullText={this.props.slate.data.body} maxCharacter={100}>
-                    <ProcessedText text={this.props.slate.data.body} />
-                  </ViewAllButton>
+                  <ProcessedText text={this.props.slate.data.body} />
                 </div>
               ) : (
                 <div style={{ height: "8px" }} />
@@ -329,9 +319,7 @@ export class SlatePreviewBlock extends React.Component {
               <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
               {this.props.slate.data.body ? (
                 <div css={STYLES_BODY}>
-                  <ViewAllButton noButton fullText={this.props.slate.data.body} maxCharacter={100}>
-                    <ProcessedText text={this.props.slate.data.body} />
-                  </ViewAllButton>
+                  <ProcessedText text={this.props.slate.data.body} />
                 </div>
               ) : (
                 <div style={{ height: "8px" }} />

--- a/node_common/data/index.js
+++ b/node_common/data/index.js
@@ -18,6 +18,7 @@ import createSlate from "~/node_common/data/methods/create-slate";
 import getSlateByName from "~/node_common/data/methods/get-slate-by-name";
 import getSlateById from "~/node_common/data/methods/get-slate-by-id";
 import getSlatesByUserId from "~/node_common/data/methods/get-slates-by-user-id";
+import getSlatesByIds from "~/node_common/data/methods/get-slates-by-ids";
 import getSlateObjectsByCID from "~/node_common/data/methods/get-slate-objects-by-cid";
 import updateSlateById from "~/node_common/data/methods/update-slate-by-id";
 import deleteSlatesForUserId from "~/node_common/data/methods/delete-slates-for-user-id";
@@ -89,6 +90,7 @@ export {
   getSlateByName,
   getSlateById,
   getSlatesByUserId,
+  getSlatesByIds,
   getSlateObjectsByCID,
   updateSlateById,
   deleteSlatesForUserId,

--- a/node_common/data/methods/get-slates-by-ids.js
+++ b/node_common/data/methods/get-slates-by-ids.js
@@ -1,0 +1,38 @@
+import { runQuery } from "~/node_common/data/utilities";
+
+export default async ({ id }) => {
+  return await runQuery({
+    label: "GET_SLATES_BY_IDS",
+    queryFn: async (DB) => {
+      const query = await DB.select("*").from("slates").whereIn("id", [
+        //NOTE(tara): slates in localhost for testing
+        "857ad84d-7eff-4861-a988-65c84b62fc23",
+        "81fa0b39-0e96-4c7f-8587-38468bb67cb3",
+        "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29",
+        "df05cb1f-2ecf-4872-b111-c4b8493d08f8",
+        "435035e6-dee4-4bbf-9521-64c219a527e7",
+        "ac907aa3-2fb2-46fd-8eba-ec8ceb87b5eb",
+
+        //NOTE(tara): slates in prod
+        // "d2861ac4-fc41-4c07-8f21-d0bf06be364c",
+        // "9c2c458c-d92a-4e81-a4b6-bf6ab4607470",
+        // "7f461144-0647-43d7-8294-788b37ae5979",
+        // "f72c2594-b8ac-41f6-91e0-b2da6788ae23",
+        // "a0d6e2f2-564d-47ed-bf56-13c42634703d",
+        // "0ba92c73-92e7-4b00-900e-afae4856c9ea",
+      ]);
+
+      if (!query || query.error) {
+        return [];
+      }
+
+      return JSON.parse(JSON.stringify(query));
+    },
+    errorFn: async (e) => {
+      return {
+        error: true,
+        decorator: "GET_SLATES_BY_IDS",
+      };
+    },
+  });
+};

--- a/pages/_/profile.js
+++ b/pages/_/profile.js
@@ -38,6 +38,7 @@ export default class ProfilePage extends React.Component {
     if (Strings.isEmpty(image)) {
       image = DEFAULT_IMAGE;
     }
+    console.log(this.props);
 
     return (
       <WebsitePrototypeWrapper title={title} description={description} url={url} image={image}>

--- a/pages/api/slates/get.js
+++ b/pages/api/slates/get.js
@@ -26,21 +26,28 @@ export default async (req, res) => {
     });
   }
 
-  const response = await Data.getSlateById({ id: req.body.data.id });
+  if (Array.isArray(req.body.data.id)) {
+    const responseMultiple = Data.getSlatesByIds({ id: req.body.data.id });
+    if (!responseMultiple) {
+      return res.status(404).send({ decorator: "SERVER_GET_SLATES_NOT_FOUND", error: true });
+    }
 
-  if (!response) {
-    return res
-      .status(404)
-      .send({ decorator: "SERVER_GET_SLATE_NOT_FOUND", error: true });
+    if (responseMultiple.error) {
+      return res.status(500).send({ decorator: "SERVER_GET_SLATES_NOT_FOUND", error: true });
+    }
+    console.log(responseMultiple);
+
+    return res.status(200).send({ decorator: "SERVER_GET_SLATES", slate: responseMultiple });
+  } else {
+    const response = await Data.getSlateById({ id: req.body.data.id });
+    if (!response) {
+      return res.status(404).send({ decorator: "SERVER_GET_SLATE_NOT_FOUND", error: true });
+    }
+
+    if (response.error) {
+      return res.status(500).send({ decorator: "SERVER_GET_SLATE_NOT_FOUND", error: true });
+    }
+
+    return res.status(200).send({ decorator: "SERVER_GET_SLATE", slate: response });
   }
-
-  if (response.error) {
-    return res
-      .status(500)
-      .send({ decorator: "SERVER_GET_SLATE_NOT_FOUND", error: true });
-  }
-
-  return res
-    .status(200)
-    .send({ decorator: "SERVER_UPDATE_SLATE", slate: response });
 };

--- a/server.js
+++ b/server.js
@@ -224,11 +224,30 @@ app.prepare().then(async () => {
       publicOnly: true,
     });
 
+    const exploreSlates = await Data.getSlatesByIds("id", [
+      //NOTE(tara): slates in localhost for testing
+      "857ad84d-7eff-4861-a988-65c84b62fc23",
+      "81fa0b39-0e96-4c7f-8587-38468bb67cb3",
+      "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29",
+      "df05cb1f-2ecf-4872-b111-c4b8493d08f8",
+      "435035e6-dee4-4bbf-9521-64c219a527e7",
+      "ac907aa3-2fb2-46fd-8eba-ec8ceb87b5eb",
+
+      //NOTE(tara): slates in prod
+      // "d2861ac4-fc41-4c07-8f21-d0bf06be364c",
+      // "9c2c458c-d92a-4e81-a4b6-bf6ab4607470",
+      // "7f461144-0647-43d7-8294-788b37ae5979",
+      // "f72c2594-b8ac-41f6-91e0-b2da6788ae23",
+      // "a0d6e2f2-564d-47ed-bf56-13c42634703d",
+      // "0ba92c73-92e7-4b00-900e-afae4856c9ea",
+    ]);
+
     return app.render(req, res, "/_/profile", {
       viewer,
       creator: Serializers.user({ ...creator, slates }),
       mobile,
       resources: EXTERNAL_RESOURCES,
+      exploreSlates,
     });
   });
 


### PR DESCRIPTION
- external profile view when users doesn't have any publicly shared slates 
- design tweaks on slate preview blocks to align with current design from Haris.
- the current explore slate content is for testing purposes, I will have to swap out the IDs when pushing to prod.
<img width="1792" alt="Screen Shot 2020-11-11 at 11 04 42 AM" src="https://user-images.githubusercontent.com/35607644/98854633-a79b1500-240f-11eb-9c40-859d37de5669.png">
<img width="1792" alt="Screen Shot 2020-11-11 at 11 18 50 AM" src="https://user-images.githubusercontent.com/35607644/98854660-aff35000-240f-11eb-8b75-f6129500bb8f.png">
