### PR TITLE
empty profile view & styling tweaks

### DIFF
--- a/common/actions.js
+++ b/common/actions.js
@@ -86,6 +86,13 @@ export const getSlateById = async (data) => {
   });
 };
 
+export const getSlatesByIds = async (data) => {
+  return await returnJSON(`/api/slates/get`, {
+    ...DEFAULT_OPTIONS,
+    body: JSON.stringify({ data }),
+  });
+};
+
 export const deleteTrustRelationship = async (data) => {
   return await returnJSON(`/api/users/trust-delete`, {
     ...DEFAULT_OPTIONS,

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as Constants from "~/common/constants";
 import * as Strings from "~/common/strings";
-import * as SVG from "~/common/svg";
 
 import { css } from "@emotion/core";
 import { ProcessedText } from "~/components/system/components/Typography";
@@ -24,7 +23,6 @@ const STYLES_PROFILE = css`
   white-space: pre-wrap;
   flex-shrink: 0;
   display: block;
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     padding: 80px 24px 0px 24px;
   }
@@ -36,7 +34,6 @@ const STYLES_PROFILE_INFO = css`
   width: 50%;
   overflow-wrap: break-word;
   white-space: pre-wrap;
-
   @media (max-width: ${Constants.sizes.tablet}px) {
     width: 100%;
   }
@@ -58,7 +55,6 @@ const STYLES_INFO_INTERNAL = css`
   margin-bottom: 48px;
   overflow-wrap: break-word;
   white-space: pre-wrap;
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     max-width: calc(100% - 64px);
   }
@@ -72,7 +68,6 @@ const STYLES_INFO = css`
   margin-bottom: 48px;
   overflow-wrap: break-word;
   white-space: pre-wrap;
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     max-width: calc(100% - 80px);
   }
@@ -86,8 +81,7 @@ const STYLES_PROFILE_IMAGE = css`
   height: 80px;
   flex-shrink: 0;
   border-radius: 4px;
-  margin-right: 24px;
-
+  margin: 8px 24px 0 0;
   @media (max-width: ${Constants.sizes.mobile}px) {
     width: 64px;
     height: 64px;
@@ -96,33 +90,34 @@ const STYLES_PROFILE_IMAGE = css`
 `;
 
 const STYLES_NAME = css`
-  font-size: ${Constants.typescale.lvl4};
+  font-size: ${Constants.typescale.lvl3};
   font-family: ${Constants.font.medium};
   max-width: 100%;
   font-weight: 400;
-  margin-top: 8px;
-  margin-right: 24px;
+  margin: 8px 24px 0px 0;
   overflow-wrap: break-word;
   white-space: pre-wrap;
+  color: ${Constants.system.black};
+`;
 
+const STYLES_NAME_INTERNAL = css`
+  font-size: ${Constants.typescale.lvl3};
+  font-family: ${Constants.font.semiBold};
+  max-width: 100%;
+  font-weight: 400;
+  margin: 8px 24px 0px 0;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+  color: ${Constants.system.black};
   @media (max-width: ${Constants.sizes.mobile}px) {
     margin-bottom: 8px;
     margin-right: 0;
   }
 `;
 
-const STYLES_NAME_INTERNAL = css`
-  font-size: ${Constants.typescale.lvl3};
-  font-family: ${Constants.font.medium};
-  font-weight: 400;
-  max-width: 100%;
-  margin-top: 8px;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
-`;
-
 const STYLES_DESCRIPTION = css`
-  font-size: ${Constants.typescale.lvl1};
+  font-size: ${Constants.typescale.lvl0};
+  color: ${Constants.system.darkGray};
   width: 100%;
   overflow-wrap: break-word;
   white-space: pre-wrap;
@@ -133,63 +128,67 @@ const STYLES_DESCRIPTION = css`
 
 const STYLES_STATS = css`
   font-size: ${Constants.typescale.lvl0};
-  line-height: 1.5;
-  margin: 12px 0 24px 0;
+  margin: 16px 0 16px 0;
   display: flex;
   width: 100%;
-  flex-wrap: wrap;
+  color: ${Constants.system.grayBlack};
 `;
 
 const STYLES_STAT = css`
-  margin-right: 16px;
+  margin-right: 8px;
   width: 112px;
   flex-shrink: 0;
 `;
 
 const STYLES_BUTTON = css`
-  padding: 10px 24px;
+  width: 96px;
+  height: 36px;
+  border-radius: 4px;
+  border: 1px solid ${Constants.system.gray};
+  padding: 8px 16px;
   cursor: pointer;
-  font-family: ${Constants.font.semiBold};
+  margin-top: 8px;
+  font-family: ${Constants.font.medium};
   font-weight: 400;
   font-size: 14px;
   text-align: center;
   text-decoration: none;
-  height: 40px;
-  width: 160px;
-  border-radius: 4px;
-  color: ${Constants.system.white};
-  background-color: ${Constants.system.brand};
-
+  color: ${Constants.system.black};
+  :hover {
+    background-color: ${Constants.system.gray};
+    transition: 200ms background-color linear;
+  }
   :visited {
-    color: ${Constants.system.white};
+    color: ${Constants.system.black};
   }
 `;
 
 const STYLES_FLEX = css`
   display: flex;
-  margin-bottom: 12px;
-  align-items: baseline;
-  justify-content: space-between;
+  align-items: center;
   flex-wrap: wrap;
+`;
 
-  @media (max-width: ${Constants.sizes.tablet}px) {
-    display: block;
-  }
+const STYLES_EXPLORE = css`
+  margin: 160px auto 64px auto;
+  height: 1px;
+  width: 80px;
+  background-color: ${Constants.system.gray};
 `;
 
 export default class Profile extends React.Component {
   state = {
-    visible: false,
+    exploreSlates: [],
   };
 
   render() {
     let data = this.props.creator ? this.props.creator : this.props.data;
+    let exploreSlates = this.props.exploreSlates;
 
     let total = 0;
     for (let slate of data.slates) {
       total += slate.data.objects.length;
     }
-
     return (
       <div>
         {this.props.onAction ? (
@@ -205,15 +204,18 @@ export default class Profile extends React.Component {
               </div>
               <div css={STYLES_STATS}>
                 <div css={STYLES_STAT}>
-                  <div style={{ color: `${Constants.system.darkGray}` }}>Public data</div>
-                  <div style={{ fontFamily: `${Constants.font.medium}` }}>{total}</div>
+                  <div style={{ fontFamily: `${Constants.font.text}` }}>
+                    {total}{" "}
+                    <span style={{ color: `${Constants.system.darkGray}` }}>Public data</span>
+                  </div>
                 </div>
                 <div css={STYLES_STAT}>
-                  <div style={{ color: `${Constants.system.darkGray}` }}>Public slates</div>
-                  <div style={{ fontFamily: `${Constants.font.medium}` }}>{data.slates.length}</div>
+                  <div style={{ fontFamily: `${Constants.font.text}` }}>
+                    {data.slates.length}{" "}
+                    <span style={{ color: `${Constants.system.darkGray}` }}>Public slates</span>
+                  </div>
                 </div>
               </div>
-
               {data.data.body ? (
                 <div css={STYLES_DESCRIPTION}>
                   <ProcessedText text={data.data.body} />
@@ -231,21 +233,21 @@ export default class Profile extends React.Component {
               <div css={STYLES_INFO}>
                 <div css={STYLES_FLEX}>
                   <div css={STYLES_NAME}>{Strings.getPresentationName(data)}</div>
-                  <div css={STYLES_BUTTON}>
-                    <a css={STYLES_BUTTON} onClick={() => this.setState({ visible: true })}>
-                      Follow
-                    </a>
-                  </div>
+                  <a css={STYLES_BUTTON} href={"http://slate.host/_"}>
+                    Follow
+                  </a>
                 </div>
                 <div css={STYLES_STATS}>
                   <div css={STYLES_STAT}>
-                    <div style={{ color: `${Constants.system.darkGray}` }}>Public data</div>
-                    <div style={{ fontFamily: `${Constants.font.medium}` }}>{total}</div>
+                    <div style={{ fontFamily: `${Constants.font.text}` }}>
+                      {total}{" "}
+                      <span style={{ color: `${Constants.system.darkGray}` }}>Public data</span>
+                    </div>
                   </div>
                   <div css={STYLES_STAT}>
-                    <div style={{ color: `${Constants.system.darkGray}` }}>Public slates</div>
-                    <div style={{ fontFamily: `${Constants.font.medium}` }}>
-                      {data.slates.length}
+                    <div style={{ fontFamily: `${Constants.font.text}` }}>
+                      {data.slates.length}{" "}
+                      <span style={{ color: `${Constants.system.darkGray}` }}>Public slates</span>
                     </div>
                   </div>
                 </div>
@@ -291,7 +293,16 @@ export default class Profile extends React.Component {
                 username={data.username}
                 onAction={this.props.onAction}
               />
-            ) : null}
+            ) : (
+              <div>
+                {" "}
+                <p style={{ marginTop: 40, color: `${Constants.system.darkGray}` }}>
+                  No publicly shared slates from @{data.username}.
+                </p>
+                <div css={STYLES_EXPLORE} />
+                <SlatePreviewBlocksExternal slates={exploreSlates} />
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/components/core/SlatePreviewBlockExternal.js
+++ b/components/core/SlatePreviewBlockExternal.js
@@ -27,7 +27,6 @@ const STYLES_MOBILE_ONLY = css`
 
 const STYLES_IMAGE_ROW = css`
   overflow: hidden;
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     justify-content: center;
     margin: 0 -8px;
@@ -40,7 +39,6 @@ const STYLES_ITEM_BOX = css`
   margin: 0px 0px 4px 4px;
   box-shadow: 0px 0px 0px 1px ${Constants.system.lightBorder} inset;
   cursor: pointer;
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     margin: 0 8px;
   }
@@ -52,7 +50,6 @@ const STYLES_PLACEHOLDER = css`
   background-size: cover;
   background-position: 50% 50%;
   margin-bottom: 4px;
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     height: 100%;
   }
@@ -103,48 +100,38 @@ export class SlatePreviewRow extends React.Component {
 const STYLES_BLOCK = css`
   box-shadow: 0 0 0 0.5px ${Constants.system.lightBorder} inset,
     0 0 40px 0 ${Constants.system.shadow};
-  padding: 16px;
+  padding: 24px;
   font-size: 12px;
   text-align: left;
   cursor: pointer;
-  height: 480px;
+  height: 440px;
   width: 100%;
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     margin: 24px auto;
     height: auto;
   }
 `;
 
-const STYLES_TITLE_LINE = css`
-  width: 100%;
-  display: flex;
-  align-items: center;
-  font-size: ${Constants.typescale.lvl1};
-  margin-bottom: 8px;
-  overflow-wrap: break-word;
-`;
-
 const STYLES_BODY = css`
   font-family: ${Constants.font.text};
-  font-size: ${Constants.typescale.lvl1};
+  font-size: ${Constants.typescale.lvl0};
+  color: ${Constants.system.darkGray};
   margin-bottom: 24px;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   @media (max-width: ${Constants.sizes.mobile}px) {
     display: none;
   }
 `;
 
 const STYLES_TITLE = css`
-  font-size: ${Constants.typescale.lvl2};
-  font-family: ${Constants.font.semiBold};
+  font-size: ${Constants.typescale.lvl1};
+  font-family: ${Constants.font.medium};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin: 16px 0 0 0;
-
+  margin: 16px 0 4px 0;
   @media (max-width: ${Constants.sizes.mobile}px) {
     font-size: ${Constants.typescale.lvl1};
   }
@@ -156,13 +143,18 @@ const STYLES_PREVIEW = css`
 
 const STYLES_INFO = css`
   display: flex;
+  justify-content: space-between;
 `;
 
 const STYLES_OBJECT_COUNT = css`
   margin-top: 18px;
-  width: 15%;
-  font-size: ${Constants.typescale.lvl0};
+  width: auto;
+  font-size: ${Constants.typescale.lvlN1};
   color: ${Constants.system.darkGray};
+  margin-right: 0;
+  @media (max-width: ${Constants.sizes.mobile}px) {
+    margin-top: 18px;
+  }
 `;
 
 export class SlatePreviewBlock extends React.Component {
@@ -212,7 +204,6 @@ export class SlatePreviewBlock extends React.Component {
 
   render() {
     let first = this.props.slate.data.objects ? this.props.slate.data.objects[0] : null;
-    console.log(this.props.slate.data);
 
     return (
       <div css={STYLES_BLOCK}>
@@ -273,20 +264,19 @@ export class SlatePreviewBlock extends React.Component {
             />
           )}
           <div css={STYLES_INFO}>
-            <div css={STYLES_OBJECT_COUNT}>{this.props.slate.data.objects.length}</div>
             <div style={{ width: `85%` }}>
-              <div css={STYLES_TITLE_LINE}>
-                <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
-              </div>
+              <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
               {this.props.slate.data.body ? (
                 <div css={STYLES_BODY}>
-                  <ViewAllButton noButton fullText={this.props.slate.data.body} maxCharacter={100}>
-                    <ProcessedText text={this.props.slate.data.body} />
-                  </ViewAllButton>
+                  <ProcessedText text={this.props.slate.data.body} />
                 </div>
               ) : (
                 <div style={{ height: "8px" }} />
               )}
+            </div>
+            <div css={STYLES_OBJECT_COUNT}>
+              {this.props.slate.data.objects.length} file
+              {this.props.slate.data.objects.length > 1 ? "s" : ""}
             </div>
           </div>
         </span>
@@ -318,11 +308,19 @@ export class SlatePreviewBlock extends React.Component {
             )}
           </div>
           <div css={STYLES_INFO}>
-            <div css={STYLES_OBJECT_COUNT}>{this.props.slate.data.objects.length}</div>
             <div style={{ width: `85%` }}>
-              <div css={STYLES_TITLE_LINE}>
-                <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
-              </div>
+              <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
+              {this.props.slate.data.body ? (
+                <div css={STYLES_BODY}>
+                  <ProcessedText text={this.props.slate.data.body} />
+                </div>
+              ) : (
+                <div style={{ height: "8px" }} />
+              )}
+            </div>
+            <div css={STYLES_OBJECT_COUNT}>
+              {this.props.slate.data.objects.length} file
+              {this.props.slate.data.objects.length > 1 ? "s" : ""}
             </div>
           </div>
         </span>
@@ -332,15 +330,14 @@ export class SlatePreviewBlock extends React.Component {
 }
 
 const STYLES_LINK = css`
-  color: ${Constants.system.black};
+  color: ${Constants.system.grayBlack};
   text-decoration: none;
   width: calc(33.33% - 16px);
-  margin-bottom: 24px;
-
+  margin-bottom: 16px;
+  margin-right: 16px;
   @media (max-width: ${Constants.sizes.tablet}px) {
     width: 50%;
   }
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     width: 100%;
   }
@@ -352,8 +349,6 @@ const STYLES_SLATES = css`
   flex-wrap: wrap;
   overflow: hidden;
   padding-bottom: 48px;
-  justify-content: space-between;
-
   @media (max-width: ${Constants.sizes.mobile}px) {
     display: block;
   }

--- a/node_common/data/index.js
+++ b/node_common/data/index.js
@@ -18,6 +18,7 @@ import createSlate from "~/node_common/data/methods/create-slate";
 import getSlateByName from "~/node_common/data/methods/get-slate-by-name";
 import getSlateById from "~/node_common/data/methods/get-slate-by-id";
 import getSlatesByUserId from "~/node_common/data/methods/get-slates-by-user-id";
+import getSlatesByIds from "~/node_common/data/methods/get-slates-by-ids";
 import getSlateObjectsByCID from "~/node_common/data/methods/get-slate-objects-by-cid";
 import updateSlateById from "~/node_common/data/methods/update-slate-by-id";
 import deleteSlatesForUserId from "~/node_common/data/methods/delete-slates-for-user-id";
@@ -89,6 +90,7 @@ export {
   getSlateByName,
   getSlateById,
   getSlatesByUserId,
+  getSlatesByIds,
   getSlateObjectsByCID,
   updateSlateById,
   deleteSlatesForUserId,

--- a/node_common/data/methods/get-slates-by-ids.js
+++ b/node_common/data/methods/get-slates-by-ids.js
@@ -1,0 +1,38 @@
+import { runQuery } from "~/node_common/data/utilities";
+
+export default async ({ id }) => {
+  return await runQuery({
+    label: "GET_SLATES_BY_IDS",
+    queryFn: async (DB) => {
+      const query = await DB.select("*").from("slates").whereIn("id", [
+        //NOTE(tara): slates in localhost for testing
+        "857ad84d-7eff-4861-a988-65c84b62fc23",
+        "81fa0b39-0e96-4c7f-8587-38468bb67cb3",
+        "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29",
+        "df05cb1f-2ecf-4872-b111-c4b8493d08f8",
+        "435035e6-dee4-4bbf-9521-64c219a527e7",
+        "ac907aa3-2fb2-46fd-8eba-ec8ceb87b5eb",
+
+        //NOTE(tara): slates in prod
+        // "d2861ac4-fc41-4c07-8f21-d0bf06be364c",
+        // "9c2c458c-d92a-4e81-a4b6-bf6ab4607470",
+        // "7f461144-0647-43d7-8294-788b37ae5979",
+        // "f72c2594-b8ac-41f6-91e0-b2da6788ae23",
+        // "a0d6e2f2-564d-47ed-bf56-13c42634703d",
+        // "0ba92c73-92e7-4b00-900e-afae4856c9ea",
+      ]);
+
+      if (!query || query.error) {
+        return [];
+      }
+
+      return JSON.parse(JSON.stringify(query));
+    },
+    errorFn: async (e) => {
+      return {
+        error: true,
+        decorator: "GET_SLATES_BY_IDS",
+      };
+    },
+  });
+};

--- a/pages/api/slates/get.js
+++ b/pages/api/slates/get.js
@@ -26,21 +26,28 @@ export default async (req, res) => {
     });
   }
 
-  const response = await Data.getSlateById({ id: req.body.data.id });
+  if (Array.isArray(req.body.data.id)) {
+    const responseMultiple = Data.getSlatesByIds({ id: req.body.data.id });
+    if (!responseMultiple) {
+      return res.status(404).send({ decorator: "SERVER_GET_SLATES_NOT_FOUND", error: true });
+    }
 
-  if (!response) {
-    return res
-      .status(404)
-      .send({ decorator: "SERVER_GET_SLATE_NOT_FOUND", error: true });
+    if (responseMultiple.error) {
+      return res.status(500).send({ decorator: "SERVER_GET_SLATES_NOT_FOUND", error: true });
+    }
+    console.log(responseMultiple);
+
+    return res.status(200).send({ decorator: "SERVER_GET_SLATES", slate: responseMultiple });
+  } else {
+    const response = await Data.getSlateById({ id: req.body.data.id });
+    if (!response) {
+      return res.status(404).send({ decorator: "SERVER_GET_SLATE_NOT_FOUND", error: true });
+    }
+
+    if (response.error) {
+      return res.status(500).send({ decorator: "SERVER_GET_SLATE_NOT_FOUND", error: true });
+    }
+
+    return res.status(200).send({ decorator: "SERVER_GET_SLATE", slate: response });
   }
-
-  if (response.error) {
-    return res
-      .status(500)
-      .send({ decorator: "SERVER_GET_SLATE_NOT_FOUND", error: true });
-  }
-
-  return res
-    .status(200)
-    .send({ decorator: "SERVER_UPDATE_SLATE", slate: response });
 };

--- a/server.js
+++ b/server.js
@@ -240,11 +240,30 @@ app.prepare().then(async () => {
       publicOnly: true,
     });
 
+    const exploreSlates = await Data.getSlatesByIds("id", [
+      //NOTE(tara): slates in localhost for testing
+      "857ad84d-7eff-4861-a988-65c84b62fc23",
+      "81fa0b39-0e96-4c7f-8587-38468bb67cb3",
+      "c4e8dad7-4ba0-4f25-a92a-c73ef5522d29",
+      "df05cb1f-2ecf-4872-b111-c4b8493d08f8",
+      "435035e6-dee4-4bbf-9521-64c219a527e7",
+      "ac907aa3-2fb2-46fd-8eba-ec8ceb87b5eb",
+
+      //NOTE(tara): slates in prod
+      // "d2861ac4-fc41-4c07-8f21-d0bf06be364c",
+      // "9c2c458c-d92a-4e81-a4b6-bf6ab4607470",
+      // "7f461144-0647-43d7-8294-788b37ae5979",
+      // "f72c2594-b8ac-41f6-91e0-b2da6788ae23",
+      // "a0d6e2f2-564d-47ed-bf56-13c42634703d",
+      // "0ba92c73-92e7-4b00-900e-afae4856c9ea",
+    ]);
+
     return app.render(req, res, "/_/profile", {
       viewer,
       creator: Serializers.user({ ...creator, slates }),
       mobile,
       resources: EXTERNAL_RESOURCES,
+      exploreSlates,
     });
   });
 


### PR DESCRIPTION
- adding `getSlatesByIds` method for empty profile view explore section
- styling tweaks
<img width="1792" alt="Screen Shot 2020-11-16 at 10 06 31 PM" src="https://user-images.githubusercontent.com/35607644/99357807-68325580-2861-11eb-8e2b-c4d02c49ed64.png">
<img width="1792" alt="Screen Shot 2020-11-16 at 10 09 31 PM" src="https://user-images.githubusercontent.com/35607644/99357813-6c5e7300-2861-11eb-907b-ddabf81cf651.png">
