### PR TITLE
feat: Markdown rendering

### DIFF
--- a/components/system/components/Markdown.js
+++ b/components/system/components/Markdown.js
@@ -11,7 +11,7 @@ export const Markdown = ({ md, options }) => {
       {
         unified()
           .use(parse)
-          .use(linkifyRegex(/[@#](\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g)) // @user #tag
+          .use(linkifyRegex(/@(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g)) // @user
           .use(linkifyRegex(/^(https?):\/\/[^\s$.?#].[^\s]*$/gm)) // http(s) links
           .use(remark2react, options)
           .processSync(md).result

--- a/components/system/components/Markdown.js
+++ b/components/system/components/Markdown.js
@@ -4,6 +4,7 @@ import unified from "unified";
 import parse from "remark-parse";
 import remark2react from "remark-react";
 import gfm from "remark-gfm";
+import emoji from "remark-emoji";
 import linkifyRegex from "remark-linkify-regex";
 
 export const Markdown = ({ md, options }) => {
@@ -13,6 +14,7 @@ export const Markdown = ({ md, options }) => {
         unified()
           .use(parse)
           .use(gfm)
+          .use(emoji)
           .use(linkifyRegex(/@(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g)) // @user
           .use(linkifyRegex(/^(https?):\/\/[^\s$.?#].[^\s]*$/gm)) // http(s) links
           .use(remark2react, options)

--- a/components/system/components/Markdown.js
+++ b/components/system/components/Markdown.js
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+import unified from 'unified'
+import parse from 'remark-parse'
+import remark2react from 'remark-react'
+
+export const Markdown = ({md, options}) => {
+  return <React.Fragment>
+    {unified().use(parse).use(remark2react, options).processSync(md).result}
+  </React.Fragment>
+}

--- a/components/system/components/Markdown.js
+++ b/components/system/components/Markdown.js
@@ -11,7 +11,8 @@ export const Markdown = ({ md, options }) => {
       {
         unified()
           .use(parse)
-          .use(linkifyRegex(/[@#](\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g))
+          .use(linkifyRegex(/[@#](\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g)) // @user #tag
+          .use(linkifyRegex(/^(https?):\/\/[^\s$.?#].[^\s]*$/gm)) // http(s) links
           .use(remark2react, options)
           .processSync(md).result
       }

--- a/components/system/components/Markdown.js
+++ b/components/system/components/Markdown.js
@@ -3,6 +3,7 @@ import * as React from "react";
 import unified from "unified";
 import parse from "remark-parse";
 import remark2react from "remark-react";
+import gfm from "remark-gfm";
 import linkifyRegex from "remark-linkify-regex";
 
 export const Markdown = ({ md, options }) => {
@@ -11,6 +12,7 @@ export const Markdown = ({ md, options }) => {
       {
         unified()
           .use(parse)
+          .use(gfm)
           .use(linkifyRegex(/@(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g)) // @user
           .use(linkifyRegex(/^(https?):\/\/[^\s$.?#].[^\s]*$/gm)) // http(s) links
           .use(remark2react, options)

--- a/components/system/components/Markdown.js
+++ b/components/system/components/Markdown.js
@@ -1,11 +1,20 @@
 import * as React from "react";
 
-import unified from 'unified'
-import parse from 'remark-parse'
-import remark2react from 'remark-react'
+import unified from "unified";
+import parse from "remark-parse";
+import remark2react from "remark-react";
+import linkifyRegex from "remark-linkify-regex";
 
-export const Markdown = ({md, options}) => {
-  return <React.Fragment>
-    {unified().use(parse).use(remark2react, options).processSync(md).result}
-  </React.Fragment>
-}
+export const Markdown = ({ md, options }) => {
+  return (
+    <React.Fragment>
+      {
+        unified()
+          .use(parse)
+          .use(linkifyRegex(/[@#](\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g))
+          .use(remark2react, options)
+          .processSync(md).result
+      }
+    </React.Fragment>
+  );
+};

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -50,32 +50,19 @@ const onDeepLink = async (object) => {
   return window.open(slug);
 };
 
+const ProcessedLink = ({href, children, dark}) => {
+
+
+}
+
 const Link = ({href, children, dark}) => {
   return <a css={dark ? STYLES_LINK_DARK: STYLES_LINK} href={href} target="_blank" rel="nofollow">
       {children}
     </a>
 }
-  
-export const ProcessedText = ({ text, dark }) => {
-  let replacedText;
-  const remarkReactComponents = {
-  a: (props) => dark ? <Link dark {...props} /> : <Link {...props} />,
-  h1: function (props) {
-                return React.createElement('h2', props)
-              }
-};
-  console.log('gekki', remarkReactComponents)
 
-  return <Markdown body={text} options={{remarkReactComponents}} />
-
-
-  replacedText = StringReplace(text, /(https?:\/\/\S+)/g, (match, i) => (
-    <a css={dark ? STYLES_LINK_DARK : STYLES_LINK} key={match + i} href={match} target="_blank">
-      {match}
-    </a>
-  ));
-
-  replacedText = StringReplace(
+const LinkMention = () => {
+    replacedText = StringReplace(
     replacedText,
     /@(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g,
     (match, i) => (
@@ -89,8 +76,10 @@ export const ProcessedText = ({ text, dark }) => {
       </a>
     )
   );
+}
 
-  //NOTE(martina): previous regex: /#(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])\/(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g,
+const LinkHash = () => {
+    //NOTE(martina): previous regex: /#(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])\/(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g,
   replacedText = StringReplace(
     replacedText,
     /#(\w*[0-9a-zA-Z-_]+\/\w*[0-9a-zA-Z-_]+)/g,
@@ -107,6 +96,21 @@ export const ProcessedText = ({ text, dark }) => {
       );
     }
   );
+}
+  
+export const ProcessedText = ({ text, dark }) => {
+  let replacedText;
+  const remarkReactComponents = {
+  a: (props) => dark ? <Link dark {...props} /> : <Link {...props} />,
+};
+
+  return <Markdown md={text} options={{remarkReactComponents}} />
+
+  // replacedText = StringReplace(text, /(https?:\/\/\S+)/g, (match, i) => (
+  //   <a css={dark ? STYLES_LINK_DARK : STYLES_LINK} key={match + i} href={match} target="_blank">
+  //     {match}
+  //   </a>
+  // ));
 
   return <React.Fragment>{replacedText}</React.Fragment>;
 };

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -4,6 +4,7 @@ import * as Actions from "~/common/actions";
 import * as Strings from "~/common/strings";
 import * as StringReplace from "~/vendor/react-string-replace";
 
+import { Markdown } from './Markdown'
 import { css } from "@emotion/core";
 
 const LINK_STYLES = `
@@ -49,8 +50,24 @@ const onDeepLink = async (object) => {
   return window.open(slug);
 };
 
+const Link = ({href, children, dark}) => {
+  return <a css={dark ? STYLES_LINK_DARK: STYLES_LINK} href={href} target="_blank" rel="nofollow">
+      {children}
+    </a>
+}
+  
 export const ProcessedText = ({ text, dark }) => {
   let replacedText;
+  const remarkReactComponents = {
+  a: (props) => dark ? <Link dark {...props} /> : <Link {...props} />,
+  h1: function (props) {
+                return React.createElement('h2', props)
+              }
+};
+  console.log('gekki', remarkReactComponents)
+
+  return <Markdown body={text} options={{remarkReactComponents}} />
+
 
   replacedText = StringReplace(text, /(https?:\/\/\S+)/g, (match, i) => (
     <a css={dark ? STYLES_LINK_DARK : STYLES_LINK} key={match + i} href={match} target="_blank">

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -96,6 +96,9 @@ export const ProcessedText = ({ text, dark }) => {
     h4: P,
     h5: P,
     h6: P,
+    ol: OL,
+    ul: UL,
+    li: LI,
     a: (props) => <Link dark={dark} {...props} />,
   };
   return <Markdown md={text} options={{ remarkReactComponents }} />;

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -89,6 +89,12 @@ const Link = ({ href, children, dark }) => {
 
 export const ProcessedText = ({ text, dark }) => {
   const remarkReactComponents = {
+    h1: P,
+    h2: P,
+    h3: P,
+    h4: P,
+    h5: P,
+    h6: P,
     a: (props) => <Link dark={dark} {...props} />,
   };
   return <Markdown md={text} options={{ remarkReactComponents }} />;

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -72,7 +72,8 @@ const Link = ({ href, children, dark }) => {
       break;
     }
     case "#": {
-      // hash links
+      // hash deepLinks
+      // TODO: disabled in Markdown for now
       const tag = href.substr(1).toLowerCase();
       linkProps.href = `/${tag}`;
       linkProps.onClick = (e) => {

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -4,7 +4,7 @@ import * as Actions from "~/common/actions";
 import * as Strings from "~/common/strings";
 import * as StringReplace from "~/vendor/react-string-replace";
 
-import { Markdown } from './Markdown'
+import { Markdown } from "./Markdown";
 import { css } from "@emotion/core";
 
 const LINK_STYLES = `
@@ -50,19 +50,18 @@ const onDeepLink = async (object) => {
   return window.open(slug);
 };
 
-const ProcessedLink = ({href, children, dark}) => {
+const ProcessedLink = ({ href, children, dark }) => {};
 
-
-}
-
-const Link = ({href, children, dark}) => {
-  return <a css={dark ? STYLES_LINK_DARK: STYLES_LINK} href={href} target="_blank" rel="nofollow">
+const Link = ({ href, children, dark }) => {
+  return (
+    <a css={dark ? STYLES_LINK_DARK : STYLES_LINK} href={href} target="_blank" rel="nofollow">
       {children}
     </a>
-}
+  );
+};
 
 const LinkMention = () => {
-    replacedText = StringReplace(
+  replacedText = StringReplace(
     replacedText,
     /@(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g,
     (match, i) => (
@@ -76,10 +75,10 @@ const LinkMention = () => {
       </a>
     )
   );
-}
+};
 
 const LinkHash = () => {
-    //NOTE(martina): previous regex: /#(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])\/(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g,
+  //NOTE(martina): previous regex: /#(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])\/(\w*[0-9a-zA-Z-_]+\w*[0-9a-zA-Z-_])/g,
   replacedText = StringReplace(
     replacedText,
     /#(\w*[0-9a-zA-Z-_]+\/\w*[0-9a-zA-Z-_]+)/g,
@@ -96,15 +95,15 @@ const LinkHash = () => {
       );
     }
   );
-}
-  
+};
+
 export const ProcessedText = ({ text, dark }) => {
   let replacedText;
   const remarkReactComponents = {
-  a: (props) => dark ? <Link dark {...props} /> : <Link {...props} />,
-};
+    a: (props) => (dark ? <Link dark {...props} /> : <Link {...props} />),
+  };
 
-  return <Markdown md={text} options={{remarkReactComponents}} />
+  return <Markdown md={text} options={{ remarkReactComponents }} />;
 
   // replacedText = StringReplace(text, /(https?:\/\/\S+)/g, (match, i) => (
   //   <a css={dark ? STYLES_LINK_DARK : STYLES_LINK} key={match + i} href={match} target="_blank">

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-dom": "^16.12.0",
     "react-draggable": "^4.4.3",
     "regenerator-runtime": "^0.13.7",
+    "remark-gfm": "^1.0.0",
     "remark-linkify-regex": "^1.0.0",
     "remark-parse": "^9.0.0",
     "remark-react": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-dom": "^16.12.0",
     "react-draggable": "^4.4.3",
     "regenerator-runtime": "^0.13.7",
+    "remark-linkify-regex": "^1.0.0",
     "remark-parse": "^9.0.0",
     "remark-react": "^8.0.0",
     "three": "^0.108.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-dom": "^16.12.0",
     "react-draggable": "^4.4.3",
     "regenerator-runtime": "^0.13.7",
+    "remark-emoji": "^2.1.0",
     "remark-gfm": "^1.0.0",
     "remark-linkify-regex": "^1.0.0",
     "remark-parse": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,10 @@
     "react-dom": "^16.12.0",
     "react-draggable": "^4.4.3",
     "regenerator-runtime": "^0.13.7",
+    "remark-parse": "^9.0.0",
+    "remark-react": "^8.0.0",
     "three": "^0.108.0",
+    "unified": "^9.2.0",
     "universal-cookie": "^4.0.3",
     "uuid": "^8.0.0",
     "ws": "^7.3.1"


### PR DESCRIPTION
Implements: #165

Settled on using [remark](https://github.com/remarkjs/remark) with [unified](https://github.com/unifiedjs/unified) for ultimate flexibility, speed and integration (also used by Gatsby and MDX).

This works anywhere a `<ProcessedText />` element is used. Currently there isn't a preview mode for your own edits so we'll need to implement (and design) that in future feature.

### Demo:

![2020-11-20 at 20 40 24](https://user-images.githubusercontent.com/106938/99847924-c2d4f580-2b70-11eb-94d3-abab7776cdcd.png)
![2020-11-20 at 20 40 22](https://user-images.githubusercontent.com/106938/99847927-c4062280-2b70-11eb-9641-ee9d0641d2ac.png)


### Todo:
- [x] Process dark links
- [x] Process emojis
- [x] Process regular links
- [x] Process mention links
- [x] Process hash links
- [x] Allow image embeds
- [x] Enable Github Flavoured Markdown
- [x] Map Headers to Paragraphs
- [x] Check for correct sanitization
 