### PR TITLE
fix: remove carousel sidebar for unity games

### DIFF
--- a/components/core/SlateMediaObject.js
+++ b/components/core/SlateMediaObject.js
@@ -61,6 +61,7 @@ export default class SlateMediaObject extends React.Component {
     const url = this.props.data.url.replace("https://undefined", "https://");
     const type = this.props.data.type ? this.props.data.type : "LEGACY_NO_TYPE";
     const playType = typeMap[type] ? typeMap[type] : type;
+    const unityGameConfig = this.props.data.unityGameConfig;
 
     let element = <div css={STYLES_FAILURE}>No Preview</div>;
 
@@ -96,7 +97,7 @@ export default class SlateMediaObject extends React.Component {
 
     // TODO(jim): We will need to revisit this later.
     if (type.startsWith("application/unity")) {
-      return <UnityFrame url={url} />;
+      return <UnityFrame url={url} unityGameConfig={unityGameConfig} />;
     }
 
     return element;

--- a/components/core/UnityFrame.js
+++ b/components/core/UnityFrame.js
@@ -16,7 +16,7 @@ const loadScript = (url) =>
     script.onload = () => res(script);
   });
 
-const UnityFrame = ({ url }) => {
+const UnityFrame = ({ url, unityGameConfig }) => {
   const unityInstance = React.useRef();
   const [isLoading, setLoadingStatus] = React.useState(true);
 
@@ -39,7 +39,7 @@ const UnityFrame = ({ url }) => {
       if (window) {
         unityInstance.current = window.UnityLoader.instantiate(
           "unityContainer",
-          `${gameRootUrl}/Build/WebGL%20Repo.json`
+          `${gameRootUrl}/${unityGameConfig}`
         );
 
         setLoadingStatus(false);

--- a/components/system/components/GlobalCarousel.js
+++ b/components/system/components/GlobalCarousel.js
@@ -355,6 +355,7 @@ export class GlobalCarousel extends React.Component {
       return null;
     }
     let slide = <SlateMediaObject data={data} />;
+
     return (
       <div css={STYLES_ROOT}>
         <Alert
@@ -393,7 +394,11 @@ export class GlobalCarousel extends React.Component {
               css={STYLES_EXPANDER}
               onClick={() => this.setState({ showSidebar: !this.state.showSidebar })}
             >
-              {this.state.showSidebar ? (
+              {data.type === "application/unity" ? (
+                <div onClick={this._handleClose}>
+                  <SVG.Dismiss height="24px" />
+                </div>
+              ) : this.state.showSidebar ? (
                 <SVG.Maximize height="24px" />
               ) : (
                 <SVG.Minimize height="24px" />
@@ -405,7 +410,7 @@ export class GlobalCarousel extends React.Component {
           </div>
         </div>
         <span css={STYLES_MOBILE_HIDDEN}>
-          {this.state.carouselType === "data" ? (
+          {data.type === "application/unity" ? null : this.state.carouselType === "data" ? (
             <CarouselSidebarData
               display={this.state.showSidebar ? "block" : "none"}
               onClose={this._handleClose}


### PR DESCRIPTION
This PR removes the carousel sidebar for unity games. It also utilizes the `unityGameConfig` added to `data` after the game upload. 