### PR TITLE
temporary solution for username claiming

### DIFF
--- a/scenes/SceneEditAccount.js
+++ b/scenes/SceneEditAccount.js
@@ -167,14 +167,26 @@ export default class SceneEditAccount extends React.Component {
         },
       });
     } else if (response.error) {
-      dispatchCustomEvent({
-        name: "create-alert",
-        detail: {
-          alert: {
-            decorator: response.decorator,
+      if (response.decorator === "SERVER_USERNAME_IS_TAKEN") {
+        dispatchCustomEvent({
+          name: "create-alert",
+          detail: {
+            alert: {
+              decorator: response.decorator,
+              message: "The username is taken.",
+            },
           },
-        },
-      });
+        });
+      } else {
+        dispatchCustomEvent({
+          name: "create-alert",
+          detail: {
+            alert: {
+              decorator: response.decorator,
+            },
+          },
+        });
+      }
     }
 
     this.setState({ changingDetails: false });

--- a/scenes/SceneEditAccount.js
+++ b/scenes/SceneEditAccount.js
@@ -278,15 +278,7 @@ export default class SceneEditAccount extends React.Component {
               </System.ButtonPrimary>
             </div>
 
-            <div css={STYLES_HEADER}>Username</div>
-            <System.Input
-              name="username"
-              value={this.state.username}
-              placeholder="Username"
-              onChange={this._handleUsernameChange}
-            />
-
-            <div css={STYLES_HEADER}>Name</div>
+            <div css={STYLES_HEADER}>Display name</div>
             <System.Input
               name="name"
               value={this.state.name}
@@ -399,19 +391,44 @@ export default class SceneEditAccount extends React.Component {
         ) : null}
         {this.state.tab === 3 ? (
           <div>
-            <div css={STYLES_HEADER}>Delete your account</div>
+            <div css={STYLES_HEADER}>Change username</div>
+            <div style={{ maxWidth: 800 }}>
+              Username must be unique. <br />
+              Changing your username will make any links to your profile or slates that you
+              previously shared invalid.
+            </div>
+            <System.Input
+              containerStyle={{ marginTop: 12 }}
+              name="username"
+              value={this.state.username}
+              placeholder="Username"
+              onChange={this._handleUsernameChange}
+            />
+            <div style={{ marginTop: 24 }}>
+              <System.ButtonPrimary
+                onClick={this._handleSave}
+                loading={this.state.changingDetails}
+                style={{ width: "200px" }}
+              >
+                Change my username
+              </System.ButtonPrimary>
+            </div>
+
+            <div css={STYLES_HEADER} style={{ marginTop: 64 }}>
+              Delete your account
+            </div>
             <div style={{ maxWidth: 800 }}>
               If you choose to delete your account you will lose your Textile Hub and Powergate key.
             </div>
 
             <div style={{ marginTop: 24 }}>
-              <System.ButtonPrimary
+              <System.ButtonWarning
                 onClick={this._handleDelete}
                 loading={this.state.deleting}
                 style={{ width: "200px" }}
               >
                 Delete my account
-              </System.ButtonPrimary>
+              </System.ButtonWarning>
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
- temporarily Resolves #436 – moving username claiming under the account tab, inform user the consequences of changing usernames
- - more specific error message for when the username is taken
<img width="1792" alt="Screen Shot 2020-11-22 at 9 05 07 PM" src="https://user-images.githubusercontent.com/35607644/99930643-a5399480-2d06-11eb-87f1-8af100095a30.png">
<img width="1792" alt="Screen Shot 2020-11-24 at 8 20 23 AM" src="https://user-images.githubusercontent.com/35607644/100123421-563b4e80-2e2f-11eb-9fed-0b6b6039d2fb.png">

Next step
- think the profile section in general could use some visual overhaul, I will discuss with Haris in our design chat for approaching this systematically with our design system