### PR TITLE
Fix: Cleanup Unity events after unmount

### DIFF
--- a/components/core/UnityFrame.js
+++ b/components/core/UnityFrame.js
@@ -7,7 +7,7 @@ const STYLES_CONTAINER = css`
   width: 100%;
 `;
 
-const loadScript = (url) =>
+const _loadScript = (url) =>
   new Promise((res, rej) => {
     // NOTE (Amine): Create script
     const script = document.createElement("script");
@@ -16,36 +16,37 @@ const loadScript = (url) =>
     script.onload = () => res(script);
   });
 
-const UnityFrame = ({ url }) => {
-  const unityInstance = React.useRef();
-  const [isLoading, setLoadingStatus] = React.useState(true);
+const _cleanScripts = () => {
+  const scripts = document.getElementsByTagName("script");
+  const unityLoaderRegex = new RegExp(/UnityLoader.js/);
+  Array.from(scripts).forEach((script) => {
+    if (unityLoaderRegex.test(script.src)) {
+      script.remove();
+    }
+  });
+};
 
+const UnityFrame = ({ url }) => {
   // NOTE (daniel): url to unity game root
   const gameRootUrl = url.split("/index.html")[0];
-  const _loadScripts = async () => Promise.all([loadScript(`${gameRootUrl}/Build/UnityLoader.js`)]);
-
-  const _cleanScripts = () => {
-    const scripts = document.getElementsByTagName("script");
-    const unityLoaderRegex = new RegExp(/UnityLoader.js/);
-    Array.from(scripts).forEach((script) => {
-      if (unityLoaderRegex.test(script.src)) {
-        script.remove();
-      }
-    });
-  };
 
   React.useEffect(() => {
-    _loadScripts().then(() => {
+    let unityInstance;
+    _loadScript(`${gameRootUrl}/Build/UnityLoader.js`).then(() => {
       if (window) {
-        unityInstance.current = window.UnityLoader.instantiate(
+        unityInstance = window.UnityLoader.instantiate(
           "unityContainer",
           `${gameRootUrl}/Build/WebGL%20Repo.json`
         );
-
-        setLoadingStatus(false);
       }
     });
-    return _cleanScripts;
+    return () => {
+      // NOTE (Amine):   clean up Unity events on unmout
+      if (unityInstance) {
+        unityInstance.Quit();
+      }
+      _cleanScripts();
+    };
   }, []);
 
   return <div id="unityContainer" css={STYLES_CONTAINER} />;


### PR DESCRIPTION
This PR fixes input issues even when the UnityFrame component unmounts, but the inputs still won't work while UnityFrame is in view.