### PR TITLE
feat: range selection whilst pressing shift + click

### DIFF
--- a/components/core/DataView.js
+++ b/components/core/DataView.js
@@ -749,7 +749,7 @@ export default class DataView extends React.Component {
           topRowStyle={{ padding: "0px 16px" }}
           onMouseEnter={(i) => this.setState({ hover: i })}
           onMouseLeave={() => this.setState({ hover: null })}
-          isShiftDown={this.state.isShiftDown}
+          isShiftDown={this.isShiftDown}
         />
         {footer}
         <input

--- a/components/core/DataView.js
+++ b/components/core/DataView.js
@@ -263,7 +263,7 @@ export default class DataView extends React.Component {
 
   _handleCheckScroll = Window.debounce(this._handleScroll, 200);
 
-  _handleCheckBox = (e) => {
+  _handleTableCheckBox = (e) => {
     let checked = this.state.checked;
 
     let i = e.target.name;
@@ -313,7 +313,7 @@ export default class DataView extends React.Component {
     }
   };
 
-  _handleCheckBoxSelection = (e, i) => {
+  _handleGridCheckBox = (e, i) => {
     e.stopPropagation();
     e.preventDefault();
 
@@ -594,7 +594,7 @@ export default class DataView extends React.Component {
                             </Boundary>
                           ) : null}
                         </div>
-                        <div onClick={(e) => this._handleCheckBoxSelection(e, i)}>
+                        <div onClick={(e) => this._handleGridCheckBox(e, i)}>
                           <CheckBox
                             name={i}
                             value={!!this.state.checked[i]}
@@ -679,7 +679,7 @@ export default class DataView extends React.Component {
           <CheckBox
             name={index}
             value={!!this.state.checked[index]}
-            onChange={this._handleCheckBox}
+            onChange={this._handleTableCheckBox}
             boxStyle={{ height: 16, width: 16 }}
             style={{
               position: "relative",

--- a/components/core/DataView.js
+++ b/components/core/DataView.js
@@ -268,25 +268,11 @@ export default class DataView extends React.Component {
 
     let i = e.target.name;
     if (this.state.isShiftDown && this.state.lastSelectedItemIndex !== i) {
-      const start = Math.min(i, this.state.lastSelectedItemIndex);
-      const stop = Math.max(i, this.state.lastSelectedItemIndex) + 1;
-
-      let rangeSelected = {};
-
-      if (checked[i]) {
-        for (let i = start; i < stop; i++) {
-          delete checked[i];
-        }
-      } else {
-        for (let i = start; i < stop; i++) {
-          rangeSelected[i] = true;
-        }
-      }
-
-      let newSelection = Object.assign({}, checked, rangeSelected);
-      this.setState({ checked: newSelection, lastSelectedItemIndex: i });
-
-      return;
+      return this._handleShiftClick({
+        currentSelectedItemIndex: i,
+        lastSelectedItemIndex: this.state.lastSelectedItemIndex,
+        checked,
+      });
     }
 
     if (e.target.value === false) {
@@ -333,25 +319,11 @@ export default class DataView extends React.Component {
 
     let checked = this.state.checked;
     if (this.state.isShiftDown && this.state.lastSelectedItemIndex !== i) {
-      const start = Math.min(i, this.state.lastSelectedItemIndex);
-      const stop = Math.max(i, this.state.lastSelectedItemIndex) + 1;
-
-      let rangeSelected = {};
-
-      if (checked[i]) {
-        for (let i = start; i < stop; i++) {
-          delete checked[i];
-        }
-      } else {
-        for (let i = start; i < stop; i++) {
-          rangeSelected[i] = true;
-        }
-      }
-
-      let newSelection = Object.assign({}, checked, rangeSelected);
-      this.setState({ checked: newSelection, lastSelectedItemIndex: i });
-
-      return;
+      return this._handleShiftClick({
+        currentSelectedItemIndex: i,
+        lastSelectedItemIndex: this.state.lastSelectedItemIndex,
+        checked,
+      });
     }
 
     if (checked[i]) {
@@ -360,6 +332,26 @@ export default class DataView extends React.Component {
       checked[i] = true;
     }
     this.setState({ checked, lastSelectedItemIndex: i });
+  };
+
+  _handleShiftClick = ({ currentSelectedItemIndex, lastSelectedItemIndex, checked }) => {
+    const start = Math.min(currentSelectedItemIndex, lastSelectedItemIndex);
+    const stop = Math.max(currentSelectedItemIndex, lastSelectedItemIndex) + 1;
+
+    let rangeSelected = {};
+
+    for (let i = start; i < stop; i++) {
+      if (checked[currentSelectedItemIndex]) {
+        delete checked[i];
+      } else {
+        rangeSelected[i] = true;
+      }
+    }
+
+    let newSelection = Object.assign({}, checked, rangeSelected);
+    this.setState({ checked: newSelection, lastSelectedItemIndex: currentSelectedItemIndex });
+
+    return;
   };
 
   _handleDelete = async (cid, id) => {

--- a/components/core/Table.js
+++ b/components/core/Table.js
@@ -45,6 +45,26 @@ const STYLES_TABLE_TOP_ROW = css`
 `;
 
 export class Table extends React.Component {
+  tableWrapperEl = React.createRef();
+
+  componentDidMount() {
+    if (this.tableWrapperEl.current) {
+      this.tableWrapperEl.current.addEventListener("selectstart", this._handleSelectStart);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.tableWrapperEl.current) {
+      this.tableWrapperEl.current.removeEventListener("selectstart", this._handleSelectStart);
+    }
+  }
+
+  _handleSelectStart = (e) => {
+    if (this.props.isShiftDown) {
+      e.preventDefault();
+    }
+  };
+
   render() {
     const { data } = this.props;
 
@@ -63,7 +83,7 @@ export class Table extends React.Component {
 
     const width = TABLE_COLUMN_WIDTH_DEFAULTS[data.columns.length];
     return (
-      <div css={STYLES_CONTAINER} onMouseLeave={this.props.onMouseLeave}>
+      <div css={STYLES_CONTAINER} onMouseLeave={this.props.onMouseLeave} ref={this.tableWrapperEl}>
         {this.props.noLabel ? null : (
           <div css={STYLES_TABLE_TOP_ROW} style={this.props.topRowStyle}>
             {data.columns.map((c, cIndex) => {


### PR DESCRIPTION
This PR fixes Issue #400 

Now, the user can:

- select a range of items by pressing shift + click. This could be in either direction - up or down.

- can deselect a range of items by pressing shift + clicking on an item which has already been selected.
