### PR TITLE
hide actions when action bar is working

### DIFF
--- a/components/core/CarouselSidebarSlate.js
+++ b/components/core/CarouselSidebarSlate.js
@@ -164,9 +164,11 @@ export default class CarouselSidebarSlate extends React.Component {
     showFile: true,
     unsavedChanges: false,
     pickerLoading: false,
+    loading: false,
   };
 
   componentDidMount = () => {
+    window.addEventListener("slate-global-carousel-loading", this._handleSetLoading);
     if (this.props.isOwner && !this.props.external) {
       this.debounceInstance = this.debounce(() => this._handleSave(), 3000);
       let isPublic = false;
@@ -182,6 +184,14 @@ export default class CarouselSidebarSlate extends React.Component {
       }
       this.setState({ selected, isPublic });
     }
+  };
+
+  componentWillUnmount = () => {
+    window.removeEventListener("slate-global-carousel-loading", this._handleSetLoading);
+  };
+
+  _handleSetLoading = (e) => {
+    this.setState({ loading: e.detail.loading });
   };
 
   debounce = (func, ms) => {

--- a/components/core/DataView.js
+++ b/components/core/DataView.js
@@ -559,7 +559,7 @@ export default class DataView extends React.Component {
                             <SVG.MoreHorizontal height="24px" />
                           )}
 
-                          {this.state.menu === each.id ? (
+                          {this.state.menu === each.id && !this.state.loading[cid] ? (
                             <Boundary
                               captureResize={true}
                               captureScroll={false}
@@ -595,24 +595,28 @@ export default class DataView extends React.Component {
                             </Boundary>
                           ) : null}
                         </div>
-                        <div onClick={(e) => this._handleCheckBox(e, i)}>
-                          <CheckBox
-                            name={i}
-                            value={!!this.state.checked[i]}
-                            boxStyle={{
-                              height: 24,
-                              width: 24,
-                              backgroundColor: this.state.checked[i]
-                                ? Constants.system.brand
-                                : "rgba(255, 255, 255, 0.75)",
-                            }}
-                            style={{
-                              position: "absolute",
-                              bottom: 8,
-                              left: 8,
-                            }}
-                          />
-                        </div>
+                        {Object.keys(this.state.loading).every(
+                          (k) => this.state.loading[k] === false
+                        ) && (
+                          <div onClick={(e) => this._handleCheckBox(e, i)}>
+                            <CheckBox
+                              name={i}
+                              value={!!this.state.checked[i]}
+                              boxStyle={{
+                                height: 24,
+                                width: 24,
+                                backgroundColor: this.state.checked[i]
+                                  ? Constants.system.brand
+                                  : "rgba(255, 255, 255, 0.75)",
+                              }}
+                              style={{
+                                position: "absolute",
+                                bottom: 8,
+                                left: 8,
+                              }}
+                            />
+                          </div>
+                        )}
                       </React.Fragment>
                     ) : null}
                   </span>

--- a/components/core/DataView.js
+++ b/components/core/DataView.js
@@ -183,8 +183,10 @@ const STYLES_IMAGE_BOX = css`
   display: flex;
   align-items: center;
   justify-content: center;
-  ${"" /* box-shadow: 0px 0px 0px 1px ${Constants.system.lightBorder} inset,
-    0 0 40px 0 ${Constants.system.shadow}; */}
+  ${
+    "" /* box-shadow: 0px 0px 0px 1px ${Constants.system.lightBorder} inset,
+    0 0 40px 0 ${Constants.system.shadow}; */
+  }
   cursor: pointer;
   position: relative;
 
@@ -468,13 +470,18 @@ export default class DataView extends React.Component {
                 </span>
               </div>
               <div css={STYLES_RIGHT}>
-                <ButtonPrimary
-                  transparent
-                  style={{ color: Constants.system.white }}
-                  onClick={this._handleAddToSlate}
-                >
-                  Add to slate
-                </ButtonPrimary>
+                {this.state.loading &&
+                Object.values(this.state.loading).some((elem) => {
+                  return !!elem;
+                }) ? null : (
+                  <ButtonPrimary
+                    transparent
+                    style={{ color: Constants.system.white }}
+                    onClick={this._handleAddToSlate}
+                  >
+                    Add to slate
+                  </ButtonPrimary>
+                )}
                 <ButtonWarning
                   transparent
                   style={{ marginLeft: 8, color: Constants.system.white }}

--- a/components/core/DataView.js
+++ b/components/core/DataView.js
@@ -362,12 +362,12 @@ export default class DataView extends React.Component {
         let item = this.props.viewer.library[0].children[index];
         return item.id;
       });
-      this.setState({ checked: {} });
     }
 
     await this._handleLoading({ cids });
     await UserBehaviors.deleteFiles(cids, ids);
     this._handleLoading({ cids });
+    await this.setState({ checked: {} });
   };
 
   _handleSelect = (index) => {

--- a/components/core/SlateLayout.js
+++ b/components/core/SlateLayout.js
@@ -1752,20 +1752,27 @@ export class SlateLayout extends React.Component {
                   Object.values(this.state.loading).some((elem) => {
                     return !!elem;
                   }) ? null : (
-                    <ButtonPrimary transparent onClick={this._handleAddToSlate}>
-                      Add to slate
-                    </ButtonPrimary>
-                  )}
-                  {/* <ButtonPrimary transparent onClick={this._handleDownload}>
+                    <React.Fragment>
+                      <ButtonPrimary
+                        transparent
+                        style={{ marginLeft: 8, color: Constants.system.white }}
+                        onClick={this._handleAddToSlate}
+                      >
+                        Add to slate
+                      </ButtonPrimary>
+
+                      {/* <ButtonPrimary transparent onClick={this._handleDownload}>
                     Download
                   </ButtonPrimary> */}
-                  <ButtonWarning
-                    transparent
-                    style={{ marginLeft: 8, color: Constants.system.white }}
-                    onClick={this._handleRemoveFromSlate}
-                  >
-                    Remove
-                  </ButtonWarning>
+                      <ButtonWarning
+                        transparent
+                        style={{ marginLeft: 8, color: Constants.system.white }}
+                        onClick={this._handleRemoveFromSlate}
+                      >
+                        Remove
+                      </ButtonWarning>
+                    </React.Fragment>
+                  )}
                   <ButtonWarning
                     transparent
                     style={{ marginLeft: 8, color: Constants.system.white }}

--- a/components/core/SlateLayout.js
+++ b/components/core/SlateLayout.js
@@ -1072,7 +1072,6 @@ export class SlateLayout extends React.Component {
   _handleLoading = ({ cids }) => {
     let loading = this.state.loading;
     for (let cid of cids) {
-      console.log(this.state.loading);
       Events.dispatchCustomEvent({
         name: "slate-global-carousel-loading",
         detail: { loading: !this.state.loading[cid] },
@@ -1080,7 +1079,6 @@ export class SlateLayout extends React.Component {
       loading[cid] = !this.state.loading[cid];
     }
     this.setState({ loading });
-    console.log("loading", loading);
   };
 
   _stopProp = (e) => {
@@ -1293,7 +1291,11 @@ export class SlateLayout extends React.Component {
                   css={this.state.editing ? STYLES_ITEM_EDITING : STYLES_ITEM}
                   key={i}
                   name={i}
-                  onMouseEnter={() => this.setState({ hover: i })}
+                  onMouseEnter={() =>
+                    this.setState(
+                      this.state.loading[this.state.items[i].cid] ? { hover: null } : { hover: i }
+                    )
+                  }
                   onMouseLeave={() => this.setState({ hover: null })}
                   onMouseDown={this.state.editing ? (e) => this._handleMouseDown(e, i) : () => {}}
                   onClick={this.state.editing ? () => {} : () => this.props.onSelect(i)}
@@ -1349,26 +1351,30 @@ export class SlateLayout extends React.Component {
                               this.setState({ checked });
                             }}
                           >
-                            <CheckBox
-                              name={i}
-                              value={!!this.state.checked[i]}
-                              onChange={this._handleCheckBox}
-                              boxStyle={{
-                                height: 24,
-                                width: 24,
-                                backgroundColor: this.state.checked[i]
-                                  ? Constants.system.brand
-                                  : "rgba(255, 255, 255, 0.75)",
-                                boxShadow: this.state.checked[i]
-                                  ? "none"
-                                  : "0 0 0 2px #C3C3C4 inset",
-                              }}
-                              style={{
-                                position: "absolute",
-                                top: 8,
-                                left: 8,
-                              }}
-                            />
+                            {Object.keys(this.state.loading).every(
+                              (k) => this.state.loading[k] === false
+                            ) && (
+                              <CheckBox
+                                name={i}
+                                value={!!this.state.checked[i]}
+                                onChange={this._handleCheckBox}
+                                boxStyle={{
+                                  height: 24,
+                                  width: 24,
+                                  backgroundColor: this.state.checked[i]
+                                    ? Constants.system.brand
+                                    : "rgba(255, 255, 255, 0.75)",
+                                  boxShadow: this.state.checked[i]
+                                    ? "none"
+                                    : "0 0 0 2px #C3C3C4 inset",
+                                }}
+                                style={{
+                                  position: "absolute",
+                                  top: 8,
+                                  left: 8,
+                                }}
+                              />
+                            )}
                           </div>
                         )}
                         {this.state.hover !== i ? null : this.state.editing ? (

--- a/components/core/SlateLayout.js
+++ b/components/core/SlateLayout.js
@@ -235,6 +235,8 @@ const STYLES_ACTION_BAR_CONTAINER = css`
   display: flex;
   justify-content: center;
   z-index: ${Constants.zindex.header};
+  left: 10vw;
+  width: 80vw;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     display: none;
@@ -1053,7 +1055,6 @@ export class SlateLayout extends React.Component {
       for (let index of Object.keys(this.state.checked)) {
         ids.push(this.state.items[index].id);
       }
-      this.setState({ checked: {} });
     }
     let cids = [];
     for (let file of this.props.viewer.library[0].children) {
@@ -1065,6 +1066,7 @@ export class SlateLayout extends React.Component {
     await this._handleLoading({ cids });
     await UserBehaviors.deleteFiles(cids, ids);
     this._handleLoading({ cids });
+    await this.setState({ checked: {} });
   };
 
   _handleLoading = ({ cids }) => {
@@ -1755,12 +1757,6 @@ export class SlateLayout extends React.Component {
                     transparent
                     style={{ marginLeft: 8, color: Constants.system.white }}
                     onClick={this._handleRemoveFromSlate}
-                    loading={
-                      this.state.loading &&
-                      Object.values(this.state.loading).some((elem) => {
-                        return !!elem;
-                      })
-                    }
                   >
                     Remove
                   </ButtonWarning>

--- a/components/core/SlateLayout.js
+++ b/components/core/SlateLayout.js
@@ -1332,7 +1332,16 @@ export class SlateLayout extends React.Component {
                       }}
                     />
                     {this.state.loading[this.state.items[i].cid] ? (
-                      <LoaderSpinner style={{ height: 16, width: 16, marginTop: 4 }} />
+                      <LoaderSpinner
+                        style={{
+                          height: 16,
+                          width: 16,
+                          marginTop: 4,
+                          position: "absolute",
+                          bottom: 8,
+                          right: 8,
+                        }}
+                      />
                     ) : null}
                     {numChecked || this.state.hover === i ? (
                       <div css={STYLES_MOBILE_HIDDEN}>


### PR DESCRIPTION
- hide actions when action bar is working Resolve #442 
- add loader indicator in slate layout

in dataview:
<img width="1792" alt="Screen Shot 2020-12-02 at 9 32 57 PM" src="https://user-images.githubusercontent.com/35607644/100968314-f5bea800-34e5-11eb-92f7-51d472eadf4a.png">

in slatelayout:
![Screen Shot 2020-12-02 at 9 26 10 PM](https://user-images.githubusercontent.com/35607644/100968375-138c0d00-34e6-11eb-9c1f-d2d6b0da67fc.png)

