### PR TITLE
fix: get unity game config and loader from data prop 

### DIFF
--- a/components/core/SlateMediaObject.js
+++ b/components/core/SlateMediaObject.js
@@ -59,7 +59,9 @@ export default class SlateMediaObject extends React.Component {
     const url = this.props.data.url;
     const type = this.props.data.type ? this.props.data.type : "LEGACY_NO_TYPE";
     const playType = typeMap[type] ? typeMap[type] : type;
-
+    const unityGameConfig = this.props.data.unityGameConfig;
+    const unityGameLoader = this.props.data.unityGameLoader;
+    console.log(this.props.data);
     let element = <div css={STYLES_FAILURE}>No Preview</div>;
 
     if (type.startsWith("application/pdf")) {
@@ -94,7 +96,9 @@ export default class SlateMediaObject extends React.Component {
 
     // TODO(jim): We will need to revisit this later.
     if (type.startsWith("application/unity")) {
-      return <UnityFrame url={url} />;
+      return (
+        <UnityFrame url={url} unityGameConfig={unityGameConfig} unityGameLoader={unityGameLoader} />
+      );
     }
 
     return element;

--- a/components/core/UnityFrame.js
+++ b/components/core/UnityFrame.js
@@ -26,17 +26,17 @@ const _cleanScripts = () => {
   });
 };
 
-const UnityFrame = ({ url }) => {
+const UnityFrame = ({ url, unityGameLoader, unityGameConfig }) => {
   // NOTE (daniel): url to unity game root
   const gameRootUrl = url.split("/index.html")[0];
 
   React.useEffect(() => {
     let unityInstance;
-    _loadScript(`${gameRootUrl}/Build/UnityLoader.js`).then(() => {
+    _loadScript(`${gameRootUrl}/${unityGameLoader}`).then(() => {
       if (window) {
         unityInstance = window.UnityLoader.instantiate(
           "unityContainer",
-          `${gameRootUrl}/Build/WebGL%20Repo.json`
+          `${gameRootUrl}/${unityGameConfig}`
         );
       }
     });


### PR DESCRIPTION
This PR ensures that irrespective of the folder structure of the unity it is still able to load on Slate.

It passes the two things essential to load the game, i.e. `unityGameConfig` and `unityGameLoader`, as props to the `UnityFrame.js` component.

Thanks to @tarafanlin for spotting this issue.