### PR TITLE
nits styling

### DIFF
--- a/components/core/NewWebsitePrototypeHeader.js
+++ b/components/core/NewWebsitePrototypeHeader.js
@@ -8,7 +8,7 @@ const STYLES_ROOT = css`
   position: -webkit-sticky;
   position: sticky;
   top: 0;
-  padding: 24px 88px 24px 44px;
+  padding: 24px 64px;
   width: 100%;
   height: 100%;
   margin: 0 auto;

--- a/components/core/SlatePreviewBlockExternal.js
+++ b/components/core/SlatePreviewBlockExternal.js
@@ -271,9 +271,7 @@ export class SlatePreviewBlock extends React.Component {
             <div style={{ width: `85%` }}>
               <div css={STYLES_TITLE}>{this.props.slate.data.name}</div>
               {this.props.slate.data.body ? (
-                <div css={STYLES_BODY}>
-                  <ProcessedText text={this.props.slate.data.body} />
-                </div>
+                <div css={STYLES_BODY}>{this.props.slate.data.body}</div>
               ) : (
                 <div style={{ height: "8px" }} />
               )}


### PR DESCRIPTION
fix the styling for index header & external previewblocks
<img width="572" alt="Screen Shot 2020-12-08 at 10 21 06 PM" src="https://user-images.githubusercontent.com/35607644/101592774-abd13880-39a3-11eb-9450-62259b158fa9.png">
<img width="1792" alt="Screen Shot 2020-12-08 at 10 21 30 PM" src="https://user-images.githubusercontent.com/35607644/101592818-ba1f5480-39a3-11eb-8ea4-723f572f7496.png">

