### PR TITLE
feat: markdown editor

### DIFF
--- a/components/core/CarouselSidebarSlate.js
+++ b/components/core/CarouselSidebarSlate.js
@@ -11,7 +11,7 @@ import { css } from "@emotion/react";
 import { LoaderSpinner } from "~/components/system/components/Loaders";
 import { SlatePicker } from "~/components/core/SlatePicker";
 import { Input } from "~/components/system/components/Input";
-import { Textarea } from "~/components/system/components/Textarea";
+import { TextareaMD } from "~/components/system/components/TextareaMD";
 
 import ProcessedText from "~/components/core/ProcessedText";
 
@@ -343,7 +343,7 @@ export default class CarouselSidebarSlate extends React.Component {
                 ...STYLES_INPUT,
               }}
             />
-            <Textarea
+            <TextareaMD
               name="body"
               placeholder="Add notes or a description..."
               value={this.state.body}

--- a/components/core/CarouselSidebarSlate.js
+++ b/components/core/CarouselSidebarSlate.js
@@ -347,6 +347,7 @@ export default class CarouselSidebarSlate extends React.Component {
               placeholder="Add notes or a description..."
               value={this.state.body}
               onChange={this._handleChange}
+              dark
               style={STYLES_INPUT}
             />
             <Input

--- a/components/core/CarouselSidebarSlate.js
+++ b/components/core/CarouselSidebarSlate.js
@@ -344,7 +344,7 @@ export default class CarouselSidebarSlate extends React.Component {
             />
             <TextareaMD
               name="body"
-              placeholder="Add notes or a description..."
+              placeholder="Add notes or a description with markdown..."
               value={this.state.body}
               onChange={this._handleChange}
               dark

--- a/components/core/CarouselSidebarSlate.js
+++ b/components/core/CarouselSidebarSlate.js
@@ -163,7 +163,6 @@ const STYLES_INPUT = {
   backgroundColor: "transparent",
   boxShadow: "0 0 0 1px #3c3c3c inset",
   color: Constants.system.white,
-  height: 48,
 };
 
 const STYLES_DISMISS_BOX = css`

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -8,8 +8,6 @@ import "react-mde/lib/styles/css/react-mde-all.css";
 
 import { css } from "@emotion/react";
 
-import TextareaAutoSize from "~/vendor/react-textarea-autosize";
-
 function loadSuggestions(text) {
   return new Promise((accept, reject) => {
     setTimeout(() => {
@@ -42,9 +40,8 @@ export function TextareaMde(props) {
   const [selectedTab, setSelectedTab] = React.useState("write");
 
   return (
-    <div className={props.className}>
+    <div className={props.className} css={props.css}>
       <ReactMde
-        css={props.css}
         value={value}
         classes={props.classes}
         onChange={setValue}
@@ -56,9 +53,11 @@ export function TextareaMde(props) {
         loadSuggestions={loadSuggestions}
         childProps={{
           writeButton: {
-            tabIndex: -1,
+            tabIndex: 1,
           },
+          ...props.childProps,
         }}
+        readOnly={props.readOnly}
       />
     </div>
   );
@@ -85,21 +84,22 @@ const STYLES_TEXTAREA = css`
     transition: 200ms ease all;
     padding: 16px;
     box-shadow: 0 0 0 1px ${Constants.system.gray30} inset;
-  }
-  textarea::placeholder {
-    /* Chrome, Firefox, Opera, Safari 10.1+ */
-    color: ${Constants.system.darkGray};
-    opacity: 1; /* Firefox */
-  }
 
-  textarea:-ms-input-placeholder {
-    /* Internet Explorer 10-11 */
-    color: ${Constants.system.darkGray};
-  }
+    &::placeholder {
+      /* Chrome, Firefox, Opera, Safari 10.1+ */
+      color: ${Constants.system.darkGray};
+      opacity: 1; /* Firefox */
+    }
 
-  textarea::-ms-input-placeholder {
-    /* Microsoft Edge */
-    color: ${Constants.system.darkGray};
+    &:-ms-input-placeholder {
+      /* Internet Explorer 10-11 */
+      color: ${Constants.system.darkGray};
+    }
+
+    &::-ms-input-placeholder {
+      /* Microsoft Edge */
+      color: ${Constants.system.darkGray};
+    }
   }
 `;
 
@@ -108,11 +108,15 @@ export class TextareaMD extends React.Component {
     return (
       <TextareaMde
         css={STYLES_TEXTAREA}
-        classes={{ textArea: STYLES_TEXTAREA }}
-        style={this.props.style}
-        onChange={this.props.onChange}
-        placeholder={this.props.placeholder}
-        name={this.props.name}
+        childProps={{
+          textArea: {
+            style: this.props.style,
+            placeholder: this.props.placeholder,
+            name: this.props.name,
+            onChange: this.props.onChange,
+            value: this.props.value,
+          },
+        }}
         value={this.props.value}
         readOnly={this.props.readOnly}
       />

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -10,6 +10,32 @@ import { css } from "@emotion/react";
 
 import TextareaAutoSize from "~/vendor/react-textarea-autosize";
 
+function loadSuggestions(text) {
+  return new Promise((accept, reject) => {
+    setTimeout(() => {
+      const suggestions = [
+        {
+          preview: "Chris",
+          value: "@cw",
+        },
+        {
+          preview: "Jim",
+          value: "@jim",
+        },
+        {
+          preview: "Tara",
+          value: "@Tara",
+        },
+        {
+          preview: "Martina",
+          value: "@martina",
+        },
+      ].filter((i) => i.preview.toLowerCase().includes(text.toLowerCase()));
+      accept(suggestions);
+    }, 250);
+  });
+}
+
 export function TextareaMde(props) {
   // debugger;
   const [value, setValue] = React.useState(props.value);
@@ -27,7 +53,7 @@ export function TextareaMde(props) {
         generateMarkdownPreview={(markdown) =>
           Promise.resolve(<ProcessedText dark text={markdown} />)
         }
-        // loadSuggestions={loadSuggestions}
+        loadSuggestions={loadSuggestions}
         childProps={{
           writeButton: {
             tabIndex: -1,

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -8,57 +8,6 @@ import "react-mde/lib/styles/css/react-mde-all.css";
 
 import { css } from "@emotion/react";
 
-const STYLES_MDE = css`
-  box-sizing: border-box;
-  font-family: ${Constants.font.text};
-  -webkit-appearance: none;
-  background: ${Constants.system.white};
-  color: ${Constants.system.black};
-  border-radius: 4px;
-  display: flex;
-  font-size: 14px;
-  align-items: center;
-  justify-content: flex-start;
-`;
-
-const STYLES_TEXTAREA = css`
-  ${STYLES_MDE};
-  display: block;
-  textarea {
-    box-sizing: border-box;
-    font-family: ${Constants.font.text};
-    -webkit-appearance: none;
-    width: 100%;
-    min-height: 160px;
-    max-width: 480px;
-    resize: none;
-    background: ${Constants.system.white};
-    color: ${Constants.system.black};
-    font-size: 14px;
-    outline: 0;
-    border: 0;
-    transition: 200ms ease all;
-    padding: 16px;
-    box-shadow: 0 0 0 1px ${Constants.system.gray30} inset;
-    margin-bottom: 0 !important;
-    &::placeholder {
-      /* Chrome, Firefox, Opera, Safari 10.1+ */
-      color: ${Constants.system.darkGray};
-      opacity: 1; /* Firefox */
-    }
-
-    &:-ms-input-placeholder {
-      /* Internet Explorer 10-11 */
-      color: ${Constants.system.darkGray};
-    }
-
-    &::-ms-input-placeholder {
-      /* Microsoft Edge */
-      color: ${Constants.system.darkGray};
-    }
-  }
-`;
-
 function loadSuggestions(text) {
   return new Promise((accept, reject) => {
     setTimeout(() => {
@@ -90,8 +39,76 @@ export function TextareaMde(props) {
   const [value, setValue] = React.useState(props.value);
   const [selectedTab, setSelectedTab] = React.useState("write");
 
+  const COLOR_BG = props.dark ? Constants.system.black : Constants.system.white;
+  const COLOR_FG = props.dark ? Constants.system.white : Constants.system.black;
+
+  const STYLES_MDE = css`
+    box-sizing: border-box;
+    font-family: ${Constants.font.text};
+    -webkit-appearance: none;
+    background: ${COLOR_BG};
+    color: ${COLOR_FG};
+    border-radius: 4px;
+    display: flex;
+    font-size: 14px;
+    align-items: center;
+    justify-content: flex-start;
+    .mde-header {
+      background: ${COLOR_BG};
+      > ul.mde-header-group {
+        transition: 200ms ease all;
+        opacity: 1;
+        &.hidden {
+          opacity: 0;
+        }
+      }
+      > div.mde-tabs button,
+      > ul.mde-header-group li.mde-header-item button {
+        color: ${COLOR_FG};
+      }
+    }
+  `;
+
+  const STYLES_TEXTAREA = css`
+    ${STYLES_MDE};
+    display: block;
+    textarea {
+      box-sizing: border-box;
+      font-family: ${Constants.font.text};
+      -webkit-appearance: none;
+      width: 100%;
+      min-height: 160px;
+      max-width: 480px;
+      resize: none;
+      background: ${COLOR_BG};
+      color: ${COLOR_FG};
+      font-size: 14px;
+      outline: 0;
+      border: 0;
+      transition: 200ms ease all;
+      padding: 16px;
+      box-shadow: 0 0 0 1px ${Constants.system.gray30} inset;
+      margin-bottom: 0 !important;
+      &::placeholder {
+        /* Chrome, Firefox, Opera, Safari 10.1+ */
+        color: ${Constants.system.darkGray};
+        opacity: 1; /* Firefox */
+      }
+
+      &:-ms-input-placeholder {
+        /* Internet Explorer 10-11 */
+        color: ${Constants.system.darkGray};
+      }
+
+      &::-ms-input-placeholder {
+        /* Microsoft Edge */
+        color: ${Constants.system.darkGray};
+      }
+    }
+  `;
+
   return (
-    <div className={props.className} css={props.css} style={props.style}>
+    <div className={props.className} css={STYLES_TEXTAREA} style={props.style}>
       <ReactMde
         value={value}
         classes={props.classes}
@@ -99,7 +116,7 @@ export function TextareaMde(props) {
         selectedTab={selectedTab}
         onTabChange={setSelectedTab}
         generateMarkdownPreview={(markdown) =>
-          Promise.resolve(<ProcessedText dark text={markdown} />)
+          Promise.resolve(<ProcessedText dark={!!props.dark} text={markdown} />)
         }
         loadSuggestions={loadSuggestions}
         childProps={{
@@ -118,7 +135,7 @@ export class TextareaMD extends React.Component {
   render() {
     return (
       <TextareaMde
-        css={STYLES_TEXTAREA}
+        dark={this.props.dark}
         style={this.props.style}
         childProps={{
           textArea: {

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -53,8 +53,13 @@ export function TextareaMde(props) {
     font-size: 14px;
     align-items: center;
     justify-content: flex-start;
+    .react-mde {
+      border: 0;
+      border-bottom: 0;
+    }
     .mde-header {
       background: ${COLOR_BG};
+      border-bottom: 1px solid #3c3c3c;
       > ul.mde-header-group {
         transition: 200ms ease all;
         opacity: 1;
@@ -62,10 +67,18 @@ export function TextareaMde(props) {
           opacity: 0;
         }
       }
+      > div.mde-tabs button {
+        opacity: 0.5;
+        &.selected {
+          opacity: 1;
+        }
+      }
       > div.mde-tabs button,
       > ul.mde-header-group li.mde-header-item button {
         outline: 0;
         color: ${COLOR_FG};
+        font-family: ${Constants.font.text};
+        border: 0;
       }
     }
   `;
@@ -86,7 +99,6 @@ export function TextareaMde(props) {
       font-size: 14px;
       outline: 0;
       border: 0;
-      transition: 200ms ease all;
       padding: 16px;
       box-shadow: 0 0 0 1px ${Constants.system.gray30} inset;
       margin-bottom: 0 !important;

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -56,29 +56,38 @@ export function TextareaMde(props) {
     .react-mde {
       border: 0;
       border-bottom: 0;
-    }
-    .mde-header {
-      background: ${COLOR_BG};
-      border-bottom: 1px solid #3c3c3c;
-      > ul.mde-header-group {
-        transition: 200ms ease all;
-        opacity: 1;
-        &.hidden {
-          opacity: 0;
-        }
-      }
-      > div.mde-tabs button {
-        opacity: 0.5;
-        &.selected {
-          opacity: 1;
-        }
-      }
-      > div.mde-tabs button,
-      > ul.mde-header-group li.mde-header-item button {
-        outline: 0;
+      ul.mde-suggestions {
+        background: ${COLOR_BG};
         color: ${COLOR_FG};
-        font-family: ${Constants.font.text};
         border: 0;
+        border: 1px solid #3c3c3c;
+        li {
+          border-color: #3c3c3c;
+        }
+      }
+      .mde-header {
+        background: ${COLOR_BG};
+        border-bottom: 1px solid #3c3c3c;
+        > ul.mde-header-group {
+          transition: 200ms ease all;
+          opacity: 1;
+          &.hidden {
+            opacity: 0;
+          }
+        }
+        > div.mde-tabs button {
+          opacity: 0.5;
+          &.selected {
+            opacity: 1;
+          }
+        }
+        > div.mde-tabs button,
+        > ul.mde-header-group li.mde-header-item button {
+          outline: 0;
+          color: ${COLOR_FG};
+          font-family: ${Constants.font.text};
+          border: 0;
+        }
       }
     }
   `;

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -2,7 +2,8 @@ import * as React from "react";
 import * as Constants from "~/common/constants";
 
 import ReactMde from "react-mde";
-import ReactDOM from "react-dom";
+import ProcessedText from "~/components/core/ProcessedText";
+
 import "react-mde/lib/styles/css/react-mde-all.css";
 
 import { css } from "@emotion/react";
@@ -23,7 +24,9 @@ export function TextareaMde(props) {
         onChange={setValue}
         selectedTab={selectedTab}
         onTabChange={setSelectedTab}
-        // generateMarkdownPreview={(markdown) => Promise.resolve(converter.makeHtml(markdown))}
+        generateMarkdownPreview={(markdown) =>
+          Promise.resolve(<ProcessedText dark text={markdown} />)
+        }
         // loadSuggestions={loadSuggestions}
         childProps={{
           writeButton: {

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -8,6 +8,57 @@ import "react-mde/lib/styles/css/react-mde-all.css";
 
 import { css } from "@emotion/react";
 
+const STYLES_MDE = css`
+  box-sizing: border-box;
+  font-family: ${Constants.font.text};
+  -webkit-appearance: none;
+  background: ${Constants.system.white};
+  color: ${Constants.system.black};
+  border-radius: 4px;
+  display: flex;
+  font-size: 14px;
+  align-items: center;
+  justify-content: flex-start;
+`;
+
+const STYLES_TEXTAREA = css`
+  ${STYLES_MDE};
+  display: block;
+  textarea {
+    box-sizing: border-box;
+    font-family: ${Constants.font.text};
+    -webkit-appearance: none;
+    width: 100%;
+    min-height: 160px;
+    max-width: 480px;
+    resize: none;
+    background: ${Constants.system.white};
+    color: ${Constants.system.black};
+    font-size: 14px;
+    outline: 0;
+    border: 0;
+    transition: 200ms ease all;
+    padding: 16px;
+    box-shadow: 0 0 0 1px ${Constants.system.gray30} inset;
+    margin-bottom: 0 !important;
+    &::placeholder {
+      /* Chrome, Firefox, Opera, Safari 10.1+ */
+      color: ${Constants.system.darkGray};
+      opacity: 1; /* Firefox */
+    }
+
+    &:-ms-input-placeholder {
+      /* Internet Explorer 10-11 */
+      color: ${Constants.system.darkGray};
+    }
+
+    &::-ms-input-placeholder {
+      /* Microsoft Edge */
+      color: ${Constants.system.darkGray};
+    }
+  }
+`;
+
 function loadSuggestions(text) {
   return new Promise((accept, reject) => {
     setTimeout(() => {
@@ -40,7 +91,7 @@ export function TextareaMde(props) {
   const [selectedTab, setSelectedTab] = React.useState("write");
 
   return (
-    <div className={props.className} css={props.css}>
+    <div className={props.className} css={props.css} style={props.style}>
       <ReactMde
         value={value}
         classes={props.classes}
@@ -63,51 +114,12 @@ export function TextareaMde(props) {
   );
 }
 
-const STYLES_TEXTAREA = css`
-  textarea {
-    box-sizing: border-box;
-    font-family: ${Constants.font.text};
-    -webkit-appearance: none;
-    width: 100%;
-    min-height: 160px;
-    max-width: 480px;
-    resize: none;
-    background: ${Constants.system.white};
-    color: ${Constants.system.black};
-    border-radius: 4px;
-    display: flex;
-    font-size: 14px;
-    align-items: center;
-    justify-content: flex-start;
-    outline: 0;
-    border: 0;
-    transition: 200ms ease all;
-    padding: 16px;
-    box-shadow: 0 0 0 1px ${Constants.system.gray30} inset;
-
-    &::placeholder {
-      /* Chrome, Firefox, Opera, Safari 10.1+ */
-      color: ${Constants.system.darkGray};
-      opacity: 1; /* Firefox */
-    }
-
-    &:-ms-input-placeholder {
-      /* Internet Explorer 10-11 */
-      color: ${Constants.system.darkGray};
-    }
-
-    &::-ms-input-placeholder {
-      /* Microsoft Edge */
-      color: ${Constants.system.darkGray};
-    }
-  }
-`;
-
 export class TextareaMD extends React.Component {
   render() {
     return (
       <TextareaMde
         css={STYLES_TEXTAREA}
+        style={this.props.style}
         childProps={{
           textArea: {
             style: this.props.style,

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -1,0 +1,92 @@
+import * as React from "react";
+import * as Constants from "~/common/constants";
+
+import ReactMde from "react-mde";
+import ReactDOM from "react-dom";
+import "react-mde/lib/styles/css/react-mde-all.css";
+
+import { css } from "@emotion/react";
+
+import TextareaAutoSize from "~/vendor/react-textarea-autosize";
+
+export function TextareaMde(props) {
+  // debugger;
+  const [value, setValue] = React.useState(props.value);
+  const [selectedTab, setSelectedTab] = React.useState("write");
+
+  return (
+    <div className={props.className}>
+      <ReactMde
+        css={props.css}
+        value={value}
+        classes={props.classes}
+        onChange={setValue}
+        selectedTab={selectedTab}
+        onTabChange={setSelectedTab}
+        // generateMarkdownPreview={(markdown) => Promise.resolve(converter.makeHtml(markdown))}
+        // loadSuggestions={loadSuggestions}
+        childProps={{
+          writeButton: {
+            tabIndex: -1,
+          },
+        }}
+      />
+    </div>
+  );
+}
+
+const STYLES_TEXTAREA = css`
+  textarea {
+    box-sizing: border-box;
+    font-family: ${Constants.font.text};
+    -webkit-appearance: none;
+    width: 100%;
+    min-height: 160px;
+    max-width: 480px;
+    resize: none;
+    background: ${Constants.system.white};
+    color: ${Constants.system.black};
+    border-radius: 4px;
+    display: flex;
+    font-size: 14px;
+    align-items: center;
+    justify-content: flex-start;
+    outline: 0;
+    border: 0;
+    transition: 200ms ease all;
+    padding: 16px;
+    box-shadow: 0 0 0 1px ${Constants.system.gray30} inset;
+  }
+  textarea::placeholder {
+    /* Chrome, Firefox, Opera, Safari 10.1+ */
+    color: ${Constants.system.darkGray};
+    opacity: 1; /* Firefox */
+  }
+
+  textarea:-ms-input-placeholder {
+    /* Internet Explorer 10-11 */
+    color: ${Constants.system.darkGray};
+  }
+
+  textarea::-ms-input-placeholder {
+    /* Microsoft Edge */
+    color: ${Constants.system.darkGray};
+  }
+`;
+
+export class TextareaMD extends React.Component {
+  render() {
+    return (
+      <TextareaMde
+        css={STYLES_TEXTAREA}
+        classes={{ textArea: STYLES_TEXTAREA }}
+        style={this.props.style}
+        onChange={this.props.onChange}
+        placeholder={this.props.placeholder}
+        name={this.props.name}
+        value={this.props.value}
+        readOnly={this.props.readOnly}
+      />
+    );
+  }
+}

--- a/components/system/components/TextareaMD.js
+++ b/components/system/components/TextareaMD.js
@@ -64,6 +64,7 @@ export function TextareaMde(props) {
       }
       > div.mde-tabs button,
       > ul.mde-header-group li.mde-header-item button {
+        outline: 0;
         color: ${COLOR_FG};
       }
     }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dom": "^17.0.1",
     "react-draggable": "^4.4.3",
     "react-pdf": "^5.1.0",
+    "react-mde": "^11.0.6",
     "remark-emoji": "^2.1.0",
     "remark-gfm": "^1.0.0",
     "remark-linkify-regex": "^1.0.0",


### PR DESCRIPTION
This is the first sketch the integrated markdown editor, which we can use in replacement for any basic `<textarea />`. It generates markdown previews via `<ProcessedText />` to ensure the results are mapped to our system level typography components.

There's still more work to get this to fit nicely into Slate but opening this out to capture additional thoughts & input.

TODO:
- [ ] Improve styles/layout to match the design system
- [ ] Integrate lens to power the user suggestions 
- [ ] Browser testing and prop refactor
- [ ] Add custom icons?

![2021-01-29 18 13 39](https://user-images.githubusercontent.com/106938/106312157-2577fb00-625e-11eb-96b9-25e6df6df78f.gif)
