### PR TITLE
fix: unity game zip download ui improvements

### DIFF
--- a/common/messages.js
+++ b/common/messages.js
@@ -342,4 +342,8 @@ export const error = {
   SERVER_SUPPORT_MUST_PROVIDE_EMAIL: "Please provide an email where we can contact you",
   SERVER_SUPPORT_MUST_PROVIDE_MESSAGE: "Please provide a message to send",
   SERVER_SUPPORT: "We're having trouble sending your support message to the team right now",
+
+  // Unity game download
+  UNITY_ZIP_DOWNLOAD_FAILED:
+    "We're having trouble downloading you Unity game file. Please try again",
 };

--- a/common/user-behaviors.js
+++ b/common/user-behaviors.js
@@ -261,23 +261,35 @@ export const download = (file) => {
 };
 
 export const downloadZip = async (file) => {
-  const { data } = await Actions.getZipFilePaths(file);
-  const filesPaths = data.filesPaths.map((item) => item.replace(`/${file.id}/`, ""));
-  const baseUrl = file.url;
-  const zipFileName = file.file;
+  try {
+    const { data } = await Actions.getZipFilePaths(file);
+    const filesPaths = data.filesPaths.map((item) => item.replace(`/${file.id}/`, ""));
+    const baseUrl = file.url;
+    const zipFileName = file.file;
 
-  let zip = new JSZip();
+    let zip = new JSZip();
 
-  for (let filePath of filesPaths) {
-    let url = `${baseUrl}/${filePath}`;
-    const blob = await Window.getBlobFromUrl(url);
+    for (let filePath of filesPaths) {
+      let url = `${baseUrl}/${filePath}`;
+      const blob = await Window.getBlobFromUrl(url);
 
-    zip.file(filePath, blob);
+      zip.file(filePath, blob);
+    }
+
+    zip.generateAsync({ type: "blob" }).then((blob) => {
+      saveAs(blob, zipFileName);
+    });
+
+    return {
+      decorator: "UNITY_ZIP_DOWNLOAD_SUCCESS",
+      error: false,
+    };
+  } catch (e) {
+    return {
+      decorator: "UNITY_ZIP_DOWNLOAD_FAILED",
+      error: true,
+    };
   }
-
-  zip.generateAsync({ type: "blob" }).then((blob) => {
-    saveAs(blob, zipFileName);
-  });
 };
 
 // export const createSlate = async (data) => {

--- a/components/core/CarouselSidebarData.js
+++ b/components/core/CarouselSidebarData.js
@@ -221,6 +221,11 @@ const STYLES_AUTOSAVE = css`
   animation: slate-animations-autosave 4000ms ease;
 `;
 
+const STYLES_SPINNER = css`
+  width: 24px;
+  height: 24px;
+`;
+
 export const FileTypeDefaultPreview = () => {
   if (props.type && props.type.startsWith("video/")) {
     return DEFAULT_VIDEO;
@@ -500,10 +505,17 @@ export default class CarouselSidebarData extends React.Component {
           </div>
           {this.props.external ? null : (
             <div css={STYLES_ACTION} onClick={this._handleDownload}>
-              <SVG.Download height="24px" />
-              <span style={{ marginLeft: 16 }}>
-                {this.state.isDownloading ? "Downloading" : "Download"}
-              </span>
+              {this.state.isDownloading ? (
+                <>
+                  <LoaderSpinner css={STYLES_SPINNER} />
+                  <span style={{ marginLeft: 16 }}>Downloading</span>
+                </>
+              ) : (
+                <>
+                  <SVG.Download height="24px" />
+                  <span style={{ marginLeft: 16 }}>Download</span>
+                </>
+              )}
             </div>
           )}
           {this.props.isOwner ? (

--- a/components/core/CarouselSidebarData.js
+++ b/components/core/CarouselSidebarData.js
@@ -180,7 +180,7 @@ const STYLES_FILE_HIDDEN = css`
 `;
 
 const STYLES_TEXT = css`
-  color: ${Constants.system.darkGray}
+  color: ${Constants.system.darkGray};
   line-height: 1.5;
 `;
 
@@ -254,6 +254,7 @@ export default class CarouselSidebarData extends React.Component {
     changingPreview: false,
     unsavedChanges: false,
     isEditing: false,
+    isDownloading: false,
   };
 
   componentDidMount = () => {
@@ -331,7 +332,12 @@ export default class CarouselSidebarData extends React.Component {
 
   _handleDownload = () => {
     if (this.props.data.type === "application/unity") {
-      UserBehaviors.downloadZip(this.props.data);
+      this.setState({ isDownloading: true }, async () => {
+        const response = await UserBehaviors.downloadZip(this.props.data);
+        this.setState({ isDownloading: false });
+
+        Events.hasError(response);
+      });
     } else {
       UserBehaviors.download(this.props.data);
     }
@@ -495,7 +501,9 @@ export default class CarouselSidebarData extends React.Component {
           {this.props.external ? null : (
             <div css={STYLES_ACTION} onClick={this._handleDownload}>
               <SVG.Download height="24px" />
-              <span style={{ marginLeft: 16 }}>Download</span>
+              <span style={{ marginLeft: 16 }}>
+                {this.state.isDownloading ? "Downloading" : "Download"}
+              </span>
             </div>
           )}
           {this.props.isOwner ? (


### PR DESCRIPTION
This PR makes a UI improvement to the game download. Since a network request is made to Textile to get the game files and zip them, we need to show that the download is in progress (one which may take a few seconds to complete).

To do this, the download icon changes to a loading spinner and the "download" changes to "downloading" until it is completed.