### PR TITLE
feat: show user online status

### DIFF
--- a/common/browser-websockets.js
+++ b/common/browser-websockets.js
@@ -63,7 +63,6 @@ export const init = ({ resource = "", viewer, onUpdate, onNewActiveUser }) => {
       const response = JSON.parse(event.data);
       type = response.type;
       data = response.data;
-      console.log(data);
     } catch (e) {
       console.log(e);
     }

--- a/common/browser-websockets.js
+++ b/common/browser-websockets.js
@@ -8,7 +8,7 @@ let savedResource = null;
 let savedViewer = null;
 let savedOnUpdate = null;
 
-export const init = ({ resource = "", viewer, onUpdate }) => {
+export const init = ({ resource = "", viewer, onUpdate, handleActiveUsers }) => {
   savedResource = resource;
   savedViewer = viewer;
   savedOnUpdate = onUpdate;
@@ -63,6 +63,7 @@ export const init = ({ resource = "", viewer, onUpdate }) => {
       const response = JSON.parse(event.data);
       type = response.type;
       data = response.data;
+      console.log(data);
     } catch (e) {
       console.log(e);
     }
@@ -77,6 +78,10 @@ export const init = ({ resource = "", viewer, onUpdate }) => {
 
     if (type === "UPDATE") {
       onUpdate(data);
+    }
+
+    if (type === "UPDATE_USERS_ONLINE") {
+      handleActiveUsers(data);
     }
   });
 

--- a/common/browser-websockets.js
+++ b/common/browser-websockets.js
@@ -8,7 +8,7 @@ let savedResource = null;
 let savedViewer = null;
 let savedOnUpdate = null;
 
-export const init = ({ resource = "", viewer, onUpdate, handleActiveUsers }) => {
+export const init = ({ resource = "", viewer, onUpdate, onNewActiveUser }) => {
   savedResource = resource;
   savedViewer = viewer;
   savedOnUpdate = onUpdate;
@@ -81,7 +81,7 @@ export const init = ({ resource = "", viewer, onUpdate, handleActiveUsers }) => 
     }
 
     if (type === "UPDATE_USERS_ONLINE") {
-      handleActiveUsers(data);
+      onNewActiveUser(data);
     }
   });
 

--- a/common/constants.js
+++ b/common/constants.js
@@ -57,6 +57,7 @@ export const system = {
   white: "#FFFFFF",
   bgBlurGrayBlack: "rgba(15, 14, 18, 0.8)",
   bgBlurBlack: "rgba(15, 14, 18, 0.9)",
+  active: "#00BB00",
 };
 
 export const shadow = {

--- a/components/core/Application.js
+++ b/components/core/Application.js
@@ -105,6 +105,7 @@ export default class ApplicationPage extends React.Component {
     online: null,
     mobile: this.props.mobile,
     loaded: false,
+    activeUsers: null,
   };
 
   async componentDidMount() {
@@ -209,6 +210,7 @@ export default class ApplicationPage extends React.Component {
         resource: this.props.resources.pubsub,
         viewer: this.state.viewer,
         onUpdate: this._handleUpdateViewer,
+        handleActiveUsers: this._handleActiveUsers,
       });
     }
     if (!wsclient) {
@@ -218,6 +220,10 @@ export default class ApplicationPage extends React.Component {
       });
     }
     return;
+  };
+
+  _handleActiveUsers = (users) => {
+    this.setState({ activeUsers: users });
   };
 
   _handleWindowResize = () => {
@@ -631,6 +637,7 @@ export default class ApplicationPage extends React.Component {
       sceneId: current.target.id,
       mobile: this.state.mobile,
       resources: this.props.resources,
+      activeUsers: this.state.activeUsers,
     });
 
     let sidebarElement;

--- a/components/core/Application.js
+++ b/components/core/Application.js
@@ -210,7 +210,7 @@ export default class ApplicationPage extends React.Component {
         resource: this.props.resources.pubsub,
         viewer: this.state.viewer,
         onUpdate: this._handleUpdateViewer,
-        handleActiveUsers: this._handleActiveUsers,
+        onNewActiveUser: this._handleActiveUsers,
       });
     }
     if (!wsclient) {

--- a/components/core/Application.js
+++ b/components/core/Application.js
@@ -210,7 +210,7 @@ export default class ApplicationPage extends React.Component {
         resource: this.props.resources.pubsub,
         viewer: this.state.viewer,
         onUpdate: this._handleUpdateViewer,
-        onNewActiveUser: this._handleActiveUsers,
+        onNewActiveUser: this._handleNewActiveUser,
       });
     }
     if (!wsclient) {
@@ -222,7 +222,7 @@ export default class ApplicationPage extends React.Component {
     return;
   };
 
-  _handleActiveUsers = (users) => {
+  _handleNewActiveUser = (users) => {
     this.setState({ activeUsers: users });
   };
 

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -359,11 +359,7 @@ export default class Profile extends React.Component {
     const activeUsers = this.props.activeUsers;
     const userId = this.props.data.id;
 
-    if (activeUsers && activeUsers.includes(userId)) {
-      this.setState({ isOnline: true });
-    } else {
-      this.setState({ isOnline: false });
-    }
+    this.setState({ isOnline: activeUsers && activeUsers.includes(userId) });
   };
 
   render() {
@@ -525,7 +521,9 @@ export default class Profile extends React.Component {
               css={STYLES_PROFILE_IMAGE}
               style={{
                 backgroundImage: `url('${creator.data.photo}')`,
-                borderColor: this.state.isOnline ? `green` : `white`,
+                borderColor: this.state.isOnline
+                  ? Constants.system.newGreen
+                  : Constants.system.white,
               }}
             />
             <div css={STYLES_INFO}>

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -71,6 +71,7 @@ const STYLES_PROFILE_IMAGE = css`
   flex-shrink: 0;
   border-radius: 4px;
   margin: 0 auto;
+  border: 2px solid transparent;
   @media (max-width: ${Constants.sizes.mobile}px) {
     width: 64px;
     height: 64px;
@@ -259,11 +260,13 @@ export default class Profile extends React.Component {
         }).length,
     fetched: false,
     tab: this.props.tab,
+    isOnline: false,
   };
 
   componentDidMount = () => {
     this._handleUpdatePage();
     this.filterByVisibility();
+    this.checkStatus();
   };
 
   componentDidUpdate = (prevProps) => {
@@ -352,7 +355,19 @@ export default class Profile extends React.Component {
     });
   };
 
+  checkStatus = () => {
+    const activeUsers = this.props.activeUsers;
+    const userId = this.props.data.id;
+
+    if (activeUsers && activeUsers.includes(userId)) {
+      this.setState({ isOnline: true });
+    } else {
+      this.setState({ isOnline: false });
+    }
+  };
+
   render() {
+    console.log(this.state.isOnline);
     let tab = typeof this.state.tab === "undefined" || this.state.tab === null ? 1 : this.state.tab;
     let isOwner = this.props.isOwner;
     let creator = this.props.creator;
@@ -508,7 +523,10 @@ export default class Profile extends React.Component {
           <div css={STYLES_PROFILE_INFO}>
             <div
               css={STYLES_PROFILE_IMAGE}
-              style={{ backgroundImage: `url('${creator.data.photo}')` }}
+              style={{
+                backgroundImage: `url('${creator.data.photo}')`,
+                borderColor: this.state.isOnline ? `green` : `white`,
+              }}
             />
             <div css={STYLES_INFO}>
               <div css={STYLES_NAME}>{Strings.getPresentationName(creator)}</div>

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -232,7 +232,16 @@ const STYLES_COPY_INPUT = css`
   opacity: 0;
 `;
 
-function UserEntry({ user, button, onClick, message, external, url, userOnline }) {
+function UserEntry({
+  user,
+  button,
+  onClick,
+  message,
+  external,
+  url,
+  userOnline,
+  showStatusIndicator,
+}) {
   return (
     <div key={user.username} css={STYLES_USER_ENTRY}>
       {external ? (
@@ -241,13 +250,15 @@ function UserEntry({ user, button, onClick, message, external, url, userOnline }
             css={STYLES_DIRECTORY_PROFILE_IMAGE}
             style={{ backgroundImage: `url(${user.data.photo})` }}
           >
-            <div
-              css={STYLES_DIRECTORY_STATUS_INDICATOR}
-              style={{
-                borderColor: userOnline && `${Constants.system.active}`,
-                backgroundColor: userOnline && `${Constants.system.active}`,
-              }}
-            />
+            {showStatusIndicator && (
+              <div
+                css={STYLES_DIRECTORY_STATUS_INDICATOR}
+                style={{
+                  borderColor: userOnline && `${Constants.system.active}`,
+                  backgroundColor: userOnline && `${Constants.system.active}`,
+                }}
+              />
+            )}
           </div>
           <span css={STYLES_DIRECTORY_NAME}>
             {user.data.name || `@${user.username}`}
@@ -469,6 +480,7 @@ export default class Profile extends React.Component {
                 user={relation.user}
                 button={button}
                 userOnline={this.state.isOnline}
+                showStatusIndicator={this.props.isAuthenticated}
                 onClick={() => {
                   this.props.onAction({
                     type: "NAVIGATE",
@@ -522,6 +534,7 @@ export default class Profile extends React.Component {
               user={relation.owner}
               button={button}
               userOnline={this.state.isOnline}
+              showStatusIndicator={this.props.isAuthenticated}
               onClick={() => {
                 this.props.onAction({
                   type: "NAVIGATE",
@@ -541,6 +554,8 @@ export default class Profile extends React.Component {
     let total = creator.slates.reduce((total, slate) => {
       return total + slate.data?.objects?.length || 0;
     }, 0);
+
+    const showStatusIndicator = this.props.isAuthenticated;
 
     return (
       <div>
@@ -563,13 +578,15 @@ export default class Profile extends React.Component {
                 backgroundImage: `url('${creator.data.photo}')`,
               }}
             >
-              <div
-                css={STYLES_STATUS_INDICATOR}
-                style={{
-                  borderColor: this.state.isOnline && `${Constants.system.active}`,
-                  backgroundColor: this.state.isOnline && `${Constants.system.active}`,
-                }}
-              />
+              {showStatusIndicator && (
+                <div
+                  css={STYLES_STATUS_INDICATOR}
+                  style={{
+                    borderColor: this.state.isOnline && `${Constants.system.active}`,
+                    backgroundColor: this.state.isOnline && `${Constants.system.active}`,
+                  }}
+                />
+              )}
             </div>
             <div css={STYLES_INFO}>
               <div css={STYLES_NAME}>{Strings.getPresentationName(creator)}</div>

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -71,11 +71,22 @@ const STYLES_PROFILE_IMAGE = css`
   flex-shrink: 0;
   border-radius: 4px;
   margin: 0 auto;
-  border: 2px solid transparent;
+  position: relative;
   @media (max-width: ${Constants.sizes.mobile}px) {
     width: 64px;
     height: 64px;
   }
+`;
+
+const STYLES_STATUS_INDICATOR = css`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid ${Constants.system.gray50};
+  background-color: ${Constants.system.white};
 `;
 
 const STYLES_NAME = css`
@@ -184,6 +195,18 @@ const STYLES_DIRECTORY_PROFILE_IMAGE = css`
   width: 24px;
   margin-right: 16px;
   border-radius: 4px;
+  position: relative;
+`;
+
+const STYLES_DIRECTORY_STATUS_INDICATOR = css`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1.2px solid ${Constants.system.gray50};
+  background-color: ${Constants.system.white};
 `;
 
 const STYLES_MESSAGE = css`
@@ -217,7 +240,9 @@ function UserEntry({ user, button, onClick, message, external, url }) {
           <div
             css={STYLES_DIRECTORY_PROFILE_IMAGE}
             style={{ backgroundImage: `url(${user.data.photo})` }}
-          />
+          >
+            <div css={STYLES_DIRECTORY_STATUS_INDICATOR} />
+          </div>
           <span css={STYLES_DIRECTORY_NAME}>
             {user.data.name || `@${user.username}`}
             {message ? <span css={STYLES_MESSAGE}>{message}</span> : null}
@@ -357,13 +382,12 @@ export default class Profile extends React.Component {
 
   checkStatus = () => {
     const activeUsers = this.props.activeUsers;
-    const userId = this.props.data.id;
+    const userId = this.props.data?.id;
 
     this.setState({ isOnline: activeUsers && activeUsers.includes(userId) });
   };
 
   render() {
-    console.log(this.state.isOnline);
     let tab = typeof this.state.tab === "undefined" || this.state.tab === null ? 1 : this.state.tab;
     let isOwner = this.props.isOwner;
     let creator = this.props.creator;
@@ -521,11 +545,16 @@ export default class Profile extends React.Component {
               css={STYLES_PROFILE_IMAGE}
               style={{
                 backgroundImage: `url('${creator.data.photo}')`,
-                borderColor: this.state.isOnline
-                  ? Constants.system.newGreen
-                  : Constants.system.white,
               }}
-            />
+            >
+              <div
+                css={STYLES_STATUS_INDICATOR}
+                style={{
+                  borderColor: this.state.isOnline && `${Constants.system.active}`,
+                  backgroundColor: this.state.isOnline && `${Constants.system.active}`,
+                }}
+              />
+            </div>
             <div css={STYLES_INFO}>
               <div css={STYLES_NAME}>{Strings.getPresentationName(creator)}</div>
               {!isOwner && (

--- a/components/core/Profile.js
+++ b/components/core/Profile.js
@@ -232,7 +232,7 @@ const STYLES_COPY_INPUT = css`
   opacity: 0;
 `;
 
-function UserEntry({ user, button, onClick, message, external, url }) {
+function UserEntry({ user, button, onClick, message, external, url, userOnline }) {
   return (
     <div key={user.username} css={STYLES_USER_ENTRY}>
       {external ? (
@@ -241,7 +241,13 @@ function UserEntry({ user, button, onClick, message, external, url }) {
             css={STYLES_DIRECTORY_PROFILE_IMAGE}
             style={{ backgroundImage: `url(${user.data.photo})` }}
           >
-            <div css={STYLES_DIRECTORY_STATUS_INDICATOR} />
+            <div
+              css={STYLES_DIRECTORY_STATUS_INDICATOR}
+              style={{
+                borderColor: userOnline && `${Constants.system.active}`,
+                backgroundColor: userOnline && `${Constants.system.active}`,
+              }}
+            />
           </div>
           <span css={STYLES_DIRECTORY_NAME}>
             {user.data.name || `@${user.username}`}
@@ -253,7 +259,15 @@ function UserEntry({ user, button, onClick, message, external, url }) {
           <div
             css={STYLES_DIRECTORY_PROFILE_IMAGE}
             style={{ backgroundImage: `url(${user.data.photo})` }}
-          />
+          >
+            <div
+              css={STYLES_DIRECTORY_STATUS_INDICATOR}
+              style={{
+                borderColor: userOnline && `${Constants.system.active}`,
+                backgroundColor: userOnline && `${Constants.system.active}`,
+              }}
+            />
+          </div>
           <span css={STYLES_DIRECTORY_NAME}>
             {user.data.name || `@${user.username}`}
             {message ? <span css={STYLES_MESSAGE}>{message}</span> : null}
@@ -454,6 +468,7 @@ export default class Profile extends React.Component {
                 key={relation.id}
                 user={relation.user}
                 button={button}
+                userOnline={this.state.isOnline}
                 onClick={() => {
                   this.props.onAction({
                     type: "NAVIGATE",
@@ -506,6 +521,7 @@ export default class Profile extends React.Component {
               key={relation.id}
               user={relation.owner}
               button={button}
+              userOnline={this.state.isOnline}
               onClick={() => {
                 this.props.onAction({
                   type: "NAVIGATE",

--- a/pages/_/profile.js
+++ b/pages/_/profile.js
@@ -68,6 +68,7 @@ export default class ProfilePage extends React.Component {
             page={this.state.page}
             buttons={buttons}
             isOwner={false}
+            isAuthenticated={Boolean(this.props.viewer)}
             external
           />
         </div>

--- a/pages/_/profile.js
+++ b/pages/_/profile.js
@@ -68,7 +68,7 @@ export default class ProfilePage extends React.Component {
             page={this.state.page}
             buttons={buttons}
             isOwner={false}
-            isAuthenticated={Boolean(this.props.viewer)}
+            isAuthenticated={this.props.viewer !== null}
             external
           />
         </div>

--- a/scenes/SceneDirectory.js
+++ b/scenes/SceneDirectory.js
@@ -81,6 +81,18 @@ const STYLES_PROFILE_IMAGE = css`
   width: 24px;
   margin-right: 16px;
   border-radius: 4px;
+  position: relative;
+`;
+
+const STYLES_STATUS_INDICATOR = css`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 2px solid ${Constants.system.gray50};
+  background-color: ${Constants.system.white};
 `;
 
 const STYLES_MESSAGE = css`
@@ -100,11 +112,19 @@ const STYLES_NAME = css`
   text-overflow: ellipsis;
 `;
 
-function UserEntry({ user, button, onClick, message }) {
+function UserEntry({ user, button, onClick, message, userOnline }) {
   return (
     <div key={user.username} css={STYLES_USER_ENTRY}>
       <div css={STYLES_USER} onClick={onClick}>
-        <div css={STYLES_PROFILE_IMAGE} style={{ backgroundImage: `url(${user.data.photo})` }} />
+        <div css={STYLES_PROFILE_IMAGE} style={{ backgroundImage: `url(${user.data.photo})` }}>
+          <div
+            css={STYLES_STATUS_INDICATOR}
+            style={{
+              borderColor: userOnline && `${Constants.system.active}`,
+              backgroundColor: userOnline && `${Constants.system.active}`,
+            }}
+          />
+        </div>
         <span css={STYLES_NAME}>
           {user.data.name || `@${user.username}`}
           {message ? <span css={STYLES_MESSAGE}>{message}</span> : null}
@@ -139,6 +159,11 @@ export default class SceneDirectory extends React.Component {
   state = {
     copyValue: "",
     contextMenu: null,
+    isOnline: false,
+  };
+
+  componentDidMount = () => {
+    this.checkStatus();
   };
 
   _handleCopy = (e, value) => {
@@ -169,6 +194,13 @@ export default class SceneDirectory extends React.Component {
     await Actions.createSubscription({
       userId: id,
     });
+  };
+
+  checkStatus = () => {
+    const activeUsers = this.props.activeUsers;
+    const userId = this.props.data?.id;
+
+    this.setState({ isOnline: activeUsers && activeUsers.includes(userId) });
   };
 
   render() {
@@ -208,6 +240,7 @@ export default class SceneDirectory extends React.Component {
             key={relation.id}
             user={relation.user}
             button={button}
+            userOnline={this.state.isOnline}
             onClick={() => {
               this.props.onAction({
                 type: "NAVIGATE",
@@ -256,6 +289,7 @@ export default class SceneDirectory extends React.Component {
           key={relation.id}
           user={relation.owner}
           button={button}
+          userOnline={this.state.isOnline}
           onClick={() => {
             this.props.onAction({
               type: "NAVIGATE",

--- a/scenes/SceneProfile.js
+++ b/scenes/SceneProfile.js
@@ -103,6 +103,7 @@ export default class SceneProfile extends React.Component {
           this.state.profile.id === this.props.viewer.id ? this.props.viewer : this.state.profile
         }
         isOwner={this.state.profile.id === this.props.viewer.id}
+        isAuthenticated={Boolean(this.props.viewer)}
         key={this.state.profile.id}
       />
     );

--- a/scenes/SceneProfile.js
+++ b/scenes/SceneProfile.js
@@ -103,7 +103,7 @@ export default class SceneProfile extends React.Component {
           this.state.profile.id === this.props.viewer.id ? this.props.viewer : this.state.profile
         }
         isOwner={this.state.profile.id === this.props.viewer.id}
-        isAuthenticated={Boolean(this.props.viewer)}
+        isAuthenticated={this.props.viewer !== null}
         key={this.state.profile.id}
       />
     );


### PR DESCRIPTION
First iteration on user presence for multiplayer slate. Currently, it shows if a user is online. See screenshot below.
![active-profile](https://user-images.githubusercontent.com/31008944/106874254-4660a600-66cd-11eb-8ed6-568573a52449.png)

Corresponding PR for fiji here: https://github.com/slate-engineering/fiji/pull/1

TO-DO

- [x] Sync with @harisbutt and @tarafanlin about designs for presence (online/offline) for an active user and other users that the current user follows in the "Following" tab. Currently, I am simply showing a green border for when a user is online.
