### PR TITLE
feat: use new pdf renderer

### DIFF
--- a/components/core/SlateMediaObject.js
+++ b/components/core/SlateMediaObject.js
@@ -51,19 +51,6 @@ const STYLES_IMAGE = css`
   max-height: 100%;
 `;
 
-const STYLES_PDF_OBJECT = css`
-  width: 100%;
-  max-width: calc(100% - 70px);
-
-  @media (min-width: 768px) {
-    max-width: 70vw;
-  }
-
-  @media (min-width: 1024px) {
-    max-width: 60%;
-  }
-`;
-
 const typeMap = {
   "video/quicktime": "video/mp4",
 };
@@ -83,7 +70,6 @@ export default class SlateMediaObject extends React.Component {
           file={url}
           clientId={clientId}
           key={url}
-          css={STYLES_PDF_OBJECT}
           onClick={(e) => {
             e.stopPropagation();
           }}

--- a/components/core/SlateMediaObject.js
+++ b/components/core/SlateMediaObject.js
@@ -51,6 +51,19 @@ const STYLES_IMAGE = css`
   max-height: 100%;
 `;
 
+const STYLES_PDF_OBJECT = css`
+  width: 100%;
+  max-width: calc(100% - 70px);
+
+  @media (min-width: 768px) {
+    max-width: 70vw;
+  }
+
+  @media (min-width: 1024px) {
+    max-width: 60%;
+  }
+`;
+
 const typeMap = {
   "video/quicktime": "video/mp4",
 };
@@ -60,6 +73,7 @@ export default class SlateMediaObject extends React.Component {
     const url = this.props.data.url;
     const type = this.props.data.type ? this.props.data.type : "LEGACY_NO_TYPE";
     const playType = typeMap[type] ? typeMap[type] : type;
+    const clientId = this.props.adobeViewerClientId;
 
     let element = <div css={STYLES_FAILURE}>No Preview</div>;
 
@@ -67,8 +81,9 @@ export default class SlateMediaObject extends React.Component {
       return (
         <PDFViewer
           file={url}
+          clientId={clientId}
           key={url}
-          style={{ width: "calc(100% - 64px)" }}
+          css={STYLES_PDF_OBJECT}
           onClick={(e) => {
             e.stopPropagation();
           }}

--- a/components/system/components/GlobalCarousel.js
+++ b/components/system/components/GlobalCarousel.js
@@ -260,7 +260,12 @@ export class GlobalCarousel extends React.Component {
     } else if (this.props.carouselType === "DATA") {
       data.url = Strings.getCIDGatewayURL(data.cid);
     }
-    let slide = <SlateMediaObject data={data} />;
+    let slide = (
+      <SlateMediaObject
+        data={data}
+        adobeViewerClientId={this.props.resources.adobeViewerClientId}
+      />
+    );
     return (
       <div css={STYLES_ROOT}>
         <Alert

--- a/components/system/components/PDFViewer.js
+++ b/components/system/components/PDFViewer.js
@@ -14,18 +14,17 @@ const STYLES_DOCUMENT = css`
   overflow-y: scroll;
   -ms-overflow-style: none;
   scrollbar-width: none;
-
-  ::-webkit-scrollbar {
-    display: none;
-  }
+  display: grid;
+  place-items: center;
 `;
 
-const STYLES_PAGE = css`
-  margin-bottom: 20px;
+const STYLES_WRAPPER = css`
+  width: calc(100% - 120px);
+  max-width: 850px;
 `;
 
-const PDFViewer = ({ file, clientId, ...rest }) => {
-  const viewerConfig = {
+const PDFViewer = ({ file, clientId, viewerConfig, ...rest }) => {
+  viewerConfig = {
     showAnnotationTools: false,
     enableFormFilling: false,
     showLeftHandPanel: false,
@@ -37,7 +36,7 @@ const PDFViewer = ({ file, clientId, ...rest }) => {
   };
 
   const initializeViewer = () => {
-    var adobeDCView = new AdobeDC.View({
+    let adobeDCView = new AdobeDC.View({
       clientId,
       divId: "adobe-dc-view",
     });
@@ -66,7 +65,9 @@ const PDFViewer = ({ file, clientId, ...rest }) => {
       </Head>
 
       <div css={STYLES_DOCUMENT} {...rest}>
-        <div id="adobe-dc-view" />
+        <div css={STYLES_WRAPPER}>
+          <div id="adobe-dc-view" />
+        </div>
       </div>
     </>
   );

--- a/components/system/components/PDFViewer.js
+++ b/components/system/components/PDFViewer.js
@@ -1,13 +1,10 @@
 import * as React from "react";
-import { Document, Page, pdfjs } from "react-pdf";
+
+import Head from "next/head";
 
 import { css } from "@emotion/react";
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
-
 const STYLES_DOCUMENT = css`
-  display: grid;
-  place-items: center;
   margin: 0;
   padding: 20px 0 0;
   width: 100%;
@@ -27,31 +24,52 @@ const STYLES_PAGE = css`
   margin-bottom: 20px;
 `;
 
-export default class PDFViewer extends React.Component {
-  state = {
-    numPages: 0,
+const PDFViewer = ({ file, clientId, ...rest }) => {
+  const viewerConfig = {
+    showAnnotationTools: false,
+    enableFormFilling: false,
+    showLeftHandPanel: false,
+    showDownloadPDF: false,
+    showPrintPDF: false,
+    showPageControls: false,
+    dockPageControls: false,
+    embedMode: "IN_LINE",
   };
 
-  onDocumentLoadSuccess({ numPages }) {
-    this.setState({
-      numPages,
+  const initializeViewer = () => {
+    var adobeDCView = new AdobeDC.View({
+      clientId,
+      divId: "adobe-dc-view",
     });
-  }
 
-  render() {
-    const { numPages } = this.state;
-
-    return (
-      <Document
-        file={this.props.file}
-        onLoadSuccess={this.onDocumentLoadSuccess.bind(this)}
-        {...this.props}
-        css={STYLES_DOCUMENT}
-      >
-        {Array.from(new Array(numPages), (el, index) => (
-          <Page key={`page_${index + 1}`} pageNumber={index + 1} css={STYLES_PAGE} />
-        ))}
-      </Document>
+    adobeDCView.previewFile(
+      {
+        content: {
+          location: {
+            url: file,
+          },
+        },
+        metaData: { fileName: "title" },
+      },
+      viewerConfig
     );
-  }
-}
+  };
+
+  React.useEffect(() => {
+    document.addEventListener("adobe_dc_view_sdk.ready", initializeViewer);
+  });
+
+  return (
+    <>
+      <Head>
+        <script src="https://documentcloud.adobe.com/view-sdk/main.js" />
+      </Head>
+
+      <div css={STYLES_DOCUMENT} {...rest}>
+        <div id="adobe-dc-view" />
+      </div>
+    </>
+  );
+};
+
+export default PDFViewer;

--- a/node_common/environment.js
+++ b/node_common/environment.js
@@ -20,9 +20,7 @@ export const PUBSUB_SECRET = process.env.PUBSUB_SECRET;
 export const ALLOWED_HOST = process.env.ALLOWED_HOST;
 export const LOCAL_PASSWORD_ROUNDS_MANUAL = process.env.LOCAL_PASSWORD_ROUNDS_MANUAL;
 export const LOCAL_PASSWORD_ROUNDS = process.env.LOCAL_PASSWORD_ROUNDS;
-export const LOCAL_PASSWORD_SECRET = `$2b$${LOCAL_PASSWORD_ROUNDS}$${
-  process.env.LOCAL_PASSWORD_SECRET
-}`;
+export const LOCAL_PASSWORD_SECRET = `$2b$${LOCAL_PASSWORD_ROUNDS}$${process.env.LOCAL_PASSWORD_SECRET}`;
 
 // NOTE(jim): Custom avatars
 export const AVATAR_SLATE_ID = process.env.AVATAR_SLATE_ID;
@@ -42,3 +40,6 @@ export const RESOURCE_URI_UPLOAD = process.env.RESOURCE_URI_UPLOAD;
 export const RESOURCE_URI_STORAGE_UPLOAD = process.env.RESOURCE_URI_STORAGE_UPLOAD;
 export const RESOURCE_URI_PUBSUB = process.env.RESOURCE_URI_PUBSUB;
 export const RESOURCE_URI_SEARCH = process.env.RESOURCE_URI_SEARCH;
+
+// NOTE(daniel): Adobe document cloud view
+export const ADOBE_DC_VIEW_CLIENT_ID = process.env.ADOBE_DC_VIEW_CLIENT_ID;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "react-blurhash": "github:zeroxme/react-blurhash#master",
     "react-dom": "^17.0.1",
     "react-draggable": "^4.4.3",
-    "react-pdf": "^5.1.0",
     "remark-emoji": "^2.1.0",
     "remark-gfm": "^1.0.0",
     "remark-linkify-regex": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -61,6 +61,9 @@ const EXTERNAL_RESOURCES = {
     : Environment.RESOURCE_URI_STORAGE_UPLOAD,
   pubsub: Strings.isEmpty(Environment.RESOURCE_URI_PUBSUB) ? null : Environment.RESOURCE_URI_PUBSUB,
   search: Strings.isEmpty(Environment.RESOURCE_URI_SEARCH) ? null : Environment.RESOURCE_URI_SEARCH,
+  adobeViewerClientId: Strings.isEmpty(Environment.ADOBE_DC_VIEW_CLIENT_ID)
+    ? null
+    : Environment.ADOBE_DC_VIEW_CLIENT_ID,
 };
 
 let exploreSlates = [];


### PR DESCRIPTION
What better way to render PDF in slate than to use the rendering library created by Adobe, creators of the PDF?

This PR replaces react-pdf with Adobe Document Cloud PDF Embed API (https://www.adobe.io/apis/documentcloud/dcsdk/pdf-embed.html). Initial tests reveal that this is very robust, does not crash and is very responsive across devices and browsers.

 #### TODO

- [x] Improve styling in global carousel
- [ ] Make changes to systems page