### PR TITLE
fix: add Utilities import to get-serialized

### DIFF
--- a/pages/api/users/get-serialized.js
+++ b/pages/api/users/get-serialized.js
@@ -1,6 +1,7 @@
 import * as Data from "~/node_common/data";
 import * as Serializers from "~/node_common/serializers";
 import * as Strings from "~/common/strings";
+import * as Utilities from "~/node_common/utilities";
 
 export default async (req, res) => {
   const id = Utilities.getIdFromCookie(req);


### PR DESCRIPTION
fixes 500 error when accessing user data

```JS
ReferenceError: Utilities is not defined
    at resolver (webpack-internal:///./pages/api/users/get-serialized.js:9:14)
    at apiResolver (/Users/cw/root/projects/code/pl/slate/slate/node_modules/next/next-server/server/api-utils.ts:86:11)
    at processTicksAndRejections (internal/process/task_queues.js:89:5)
    at DevServer.handleApiRequest (/Users/cw/root/projects/code/pl/slate/slate/node_modules/next/next-server/server/next-server.ts:1059:5)
    at Object.fn (/Users/cw/root/projects/code/pl/slate/slate/node_modules/next/next-server/server/next-server.ts:933:27)
    at Router.execute (/Users/cw/root/projects/code/pl/slate/slate/node_modules/next/next-server/server/router.ts:247:24)
    at DevServer.run (/Users/cw/root/projects/code/pl/slate/slate/node_modules/next/next-server/server/next-server.ts:1158:23)
    at DevServer.handleRequest (/Users/cw/root/projects/code/pl/slate/slate/node_modules/next/next-server/server/next-server.ts:551:14)
```