### PR TITLE
fix: blank carousel on mobile

### DIFF
--- a/components/core/SlateMediaObject.js
+++ b/components/core/SlateMediaObject.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Constants from "~/common/constants";
 import * as Validations from "~/common/validations";
+import * as Events from "~/common/custom-events";
 
 import UnityFrame from "~/components/core/UnityFrame";
 
@@ -60,6 +61,9 @@ export default class SlateMediaObject extends React.Component {
 
     if (isMobile) {
       window.open(url, "_blank");
+      Events.dispatchCustomEvent({ name: "slate-global-close-carousel", detail: {} });
+
+      return;
     }
   };
 

--- a/components/core/SlateMediaObject.js
+++ b/components/core/SlateMediaObject.js
@@ -57,9 +57,10 @@ const typeMap = {
 
 export default class SlateMediaObject extends React.Component {
   openLink = (url) => {
-    let { isMobile } = this.props;
+    let { isMobile, data } = this.props;
+    const isPDF = data.type && data.type.startsWith("application/pdf");
 
-    if (isMobile) {
+    if (isPDF && isMobile) {
       window.open(url, "_blank");
       Events.dispatchCustomEvent({ name: "slate-global-close-carousel", detail: {} });
 


### PR DESCRIPTION
Since we open pdf in a new tab on mobile, the carousel remains blank. This PR fixes it by automatically closing the carousel after opening the pdf in a new tab on mobile. 