### PR TITLE
feat: add short urls for slate objects

### DIFF
--- a/components/core/Application.js
+++ b/components/core/Application.js
@@ -507,10 +507,10 @@ export default class ApplicationPage extends React.Component {
     const id = Window.getQueryParameterByName("scene");
     const user = Window.getQueryParameterByName("user");
     const slate = Window.getQueryParameterByName("slate");
-    const cid = Window.getQueryParameterByName("cid");
+    const shortid = Window.getQueryParameterByName("shortid");
 
     if (!Strings.isEmpty(id) && this.state.viewer) {
-      this._handleNavigateTo({ id, user, slate, cid }, null, true);
+      this._handleNavigateTo({ id, user, slate, shortid }, null, true);
       return true;
     }
     if (!this.state.loaded) {

--- a/components/system/components/GlobalCarousel.js
+++ b/components/system/components/GlobalCarousel.js
@@ -164,14 +164,14 @@ export class GlobalCarousel extends React.Component {
     }
   };
 
-  setWindowState = (cid) => {
+  setWindowState = (shortid) => {
     let baseURL = window.location.pathname.split("/");
     baseURL.length = 3;
     baseURL = baseURL.join("/");
     window.history.replaceState(
-      { ...window.history.state, cid: cid },
+      { ...window.history.state, shortid: shortid },
       null,
-      cid ? `${baseURL}/cid:${cid}` : baseURL
+      shortid ? `${baseURL}/${shortid}` : baseURL
     );
   };
 
@@ -185,7 +185,7 @@ export class GlobalCarousel extends React.Component {
     });
     if (this.props.carouselType === "SLATE") {
       const data = this.props.objects[e.detail.index];
-      this.setWindowState(data.cid);
+      this.setWindowState(data.shortid);
     }
   };
 

--- a/pages/_/slate.js
+++ b/pages/_/slate.js
@@ -184,11 +184,11 @@ export default class SlatePage extends React.Component {
         carouselType: "slate",
         slides: this.props.slate.data.objects.map((each, index) => {
           const url = each.url;
-          const cid = Strings.getCIDFromIPFS(url);
-          CIDMap[cid] = index;
+          const shortid = each.shortid;
+          CIDMap[shortid] = index;
 
           return {
-            cid,
+            shortid,
             id: each.id,
             data: each,
             isOwner: false,
@@ -198,8 +198,8 @@ export default class SlatePage extends React.Component {
       },
     });
 
-    if (!Strings.isEmpty(this.props.cid)) {
-      const index = CIDMap[this.props.cid];
+    if (!Strings.isEmpty(this.props.shortid)) {
+      const index = CIDMap[this.props.shortid];
 
       if (index || index === 0) {
         Events.dispatchCustomEvent({

--- a/pages/api/slates/add-url.js
+++ b/pages/api/slates/add-url.js
@@ -128,6 +128,7 @@ export default async (req, res) => {
       unityGameConfig: each.unityGameConfig,
       unityGameLoader: each.unityGameLoader,
       url,
+      shortid: each.shortid,
     };
   });
 

--- a/scenes/SceneSlate.js
+++ b/scenes/SceneSlate.js
@@ -223,6 +223,10 @@ class SlatePage extends React.Component {
     }
   }
 
+  componentDidMount() {
+    this._handleURLRedirect();
+  }
+
   _handleFollow = () => {
     this.setState({ isFollowing: !this.state.isFollowing });
     Actions.createSubscription({
@@ -300,6 +304,31 @@ class SlatePage extends React.Component {
     setTimeout(() => {
       this.setState({ copying: false });
     }, 1000);
+  };
+
+  _handleURLRedirect = () => {
+    const {
+      page: { shortid },
+    } = this.props;
+
+    if (shortid) {
+      const index = this.getItemIndexById(shortid);
+
+      Events.dispatchCustomEvent({
+        name: "slate-global-open-carousel",
+        detail: { index },
+      });
+
+      return;
+    }
+  };
+
+  getItemIndexById = (shortid) => {
+    const { current } = this.props;
+    const objects = current.data.objects;
+    const index = objects.findIndex((object) => object.shortid === shortid);
+
+    return index;
   };
 
   render() {

--- a/server.js
+++ b/server.js
@@ -428,6 +428,7 @@ app.prepare().then(async () => {
     });
   });
 
+  // TODO(daniel): redirect old cid links to shortid here
   server.get("/:username/:slatename/cid::cid", async (req, res) => {
     // TODO(jim): Temporary workaround
     if (!Validations.userRoute(req.params.username)) {

--- a/server.js
+++ b/server.js
@@ -503,16 +503,6 @@ app.prepare().then(async () => {
     const id = Utilities.getIdFromCookie(req);
 
     const shouldViewerRedirect = await ViewerManager.shouldRedirect({ id });
-    console.log("shouldViewerRedirect", shouldViewerRedirect);
-    const newURL = `/_${Strings.createQueryParams({
-      scene: "NAV_SLATE",
-      user: req.params.username,
-      slate: req.params.slatename,
-      shortid: req.params.shortid,
-    })}`;
-
-    console.log("newURL", newURL);
-
     if (shouldViewerRedirect) {
       return res.redirect(
         `/_${Strings.createQueryParams({
@@ -566,7 +556,7 @@ app.prepare().then(async () => {
       viewer,
       creator: Serializers.user(creator),
       slate,
-      cid: req.params.cid,
+      shortid: req.params.shortid,
     });
   });
 


### PR DESCRIPTION
This PR fixes issue #488. It replaces long cids with short url.

TO DO

- [ ] Test all actions (download, add to slate, remove from slate, delete, etc) to ensure that they have not been affected
- [ ] Redirect all cid urls to new short urls
- [ ] Add `shortid(s)`  to slate objects which have been created already 