### PR TITLE
fix: carousel sidebar rerendering

### DIFF
--- a/components/system/components/GlobalCarousel.js
+++ b/components/system/components/GlobalCarousel.js
@@ -27,6 +27,8 @@ const STYLES_ROOT = css`
   z-index: ${Constants.zindex.modal};
   background-color: rgba(0, 0, 0, 0.8);
 
+  // Note(Amine): we're using the blur filter to fix a weird backdrop-filter's bug in chrome
+  filter: blur(0px);
   @supports ((-webkit-backdrop-filter: blur(15px)) or (backdrop-filter: blur(15px))) {
     -webkit-backdrop-filter: blur(15px);
     backdrop-filter: blur(15px);


### PR DESCRIPTION
This bug took me a lot longer than expected here is my debugging journey

- There is a weird rerender in the carousel sidebar component, after searching a bit on the internet I found out that's a bug related to how chrome renders the `backdrop-filter` property
https://bugs.chromium.org/p/chromium/issues/detail?id=993971
https://bugs.chromium.org/p/chromium/issues/detail?id=497522
I spent time reading those issues but couldn't find a workaround for it, or why it happens, seems like there was a lot of use-cases where it breaks
- Next step I tried to replicate why it happens on slate, you can find it [here](https://codesandbox.io/s/filter-bug-3s25l), it turned out what was causing it, is the `GlobalCarousel` component whose background also had `backdrop-filter`, and since the sidebar component is on top of it, it had those weird rerendering behavior. 

- I tried to remove the `backdrop-filter` from the `GlobalCarrousel`, it fixed the rerendering issue but caused a flickering issue, a little bit of research I found out that `filter:blur(0px)` fixes that.

- I was curious if `filter:blur(0px)` would also fix the rerendering without the need to remove `backdrop-filter`, and it did and honestly I have no idea why it does

resolve #540 