### PR TITLE
fix: broken global carousel on page refresh or when user visit slate object url

### DIFF
--- a/scenes/SceneSlate.js
+++ b/scenes/SceneSlate.js
@@ -313,16 +313,16 @@ class SlatePage extends React.Component {
 
     /* NOTE(daniel): If user was redirected to this page, the cid of the slate object will exist in the page props. 
     We'll use the cid to open the global carousel */
-    if (cid) {
-      const index = this.getItemIndexByCID(cid);
-
-      Events.dispatchCustomEvent({
-        name: "slate-global-open-carousel",
-        detail: { index },
-      });
-
-      return;
+    if (Strings.isEmpty(cid)) {
+      return null;
     }
+
+    const index = this.getItemIndexByCID(cid);
+
+    Events.dispatchCustomEvent({
+      name: "slate-global-open-carousel",
+      detail: { index },
+    });
   };
 
   getItemIndexByCID = (cid) => {

--- a/scenes/SceneSlate.js
+++ b/scenes/SceneSlate.js
@@ -207,6 +207,10 @@ class SlatePage extends React.Component {
     }).length,
   };
 
+  componentDidMount() {
+    this._handleURLRedirect();
+  }
+
   // NOTE(jim):
   // The purpose of this is to update the Scene appropriately when
   // it changes but isn't mounted.
@@ -300,6 +304,33 @@ class SlatePage extends React.Component {
     setTimeout(() => {
       this.setState({ copying: false });
     }, 1000);
+  };
+
+  _handleURLRedirect = () => {
+    const {
+      page: { cid },
+    } = this.props;
+
+    /* NOTE(daniel): If user was redirected to this page, the cid of the slate object will exist in the page props. 
+    We'll use the cid to open the global carousel */
+    if (cid) {
+      const index = this.getItemIndexByCID(cid);
+
+      Events.dispatchCustomEvent({
+        name: "slate-global-open-carousel",
+        detail: { index },
+      });
+
+      return;
+    }
+  };
+
+  getItemIndexByCID = (cid) => {
+    const { current } = this.props;
+    const objects = current.data.objects;
+    const index = objects.findIndex((object) => object.cid === cid);
+
+    return index;
   };
 
   render() {


### PR DESCRIPTION
When the carousel is open and you refresh the page, it does not open again. It just opens the slate page containing the slate object. Also, when you copy the address to a slate object and paste in a new tab, the carousel does not open. This PR fixes these related issues.