### PR TITLE
fix slate block title cut off

### DIFF
--- a/components/core/SlatePreviewBlock.js
+++ b/components/core/SlatePreviewBlock.js
@@ -201,7 +201,6 @@ const STYLES_TITLE = css`
   text-overflow: ellipsis;
   white-space: nowrap;
   margin-right: 16px;
-  height: 24px;
 `;
 
 const STYLES_PREVIEW = css`


### PR DESCRIPTION
tiny PR fixing the text cutoff here
<img width="588" alt="Screen Shot 2021-02-19 at 9 30 28 AM" src="https://user-images.githubusercontent.com/35607644/108539960-7abf8f00-7295-11eb-9185-9a4b80996ea1.png">

should work now: 
<img width="553" alt="Screen Shot 2021-02-19 at 9 33 40 AM" src="https://user-images.githubusercontent.com/35607644/108540059-988cf400-7295-11eb-91bd-8cc2fb70c8b6.png">