### PR TITLE
feat: show slate object url in location bar on activity page

### DIFF
--- a/common/navigation-data.js
+++ b/common/navigation-data.js
@@ -44,7 +44,7 @@ export const navigation = [
     id: "NAV_ACTIVITY",
     decorator: "ACTIVITY",
     name: "Activity",
-    pageTitle: "Welcome back!",
+    pageTitle: "Activity",
     ignore: true,
   },
   {

--- a/components/system/components/GlobalCarousel.js
+++ b/components/system/components/GlobalCarousel.js
@@ -166,15 +166,23 @@ export class GlobalCarousel extends React.Component {
     }
   };
 
-  setWindowState = (cid) => {
+  setWindowState = (data) => {
     let baseURL = window.location.pathname.split("/");
     baseURL.length = 3;
     baseURL = baseURL.join("/");
-    window.history.replaceState(
-      { ...window.history.state, cid: cid },
-      null,
-      cid ? `${baseURL}/cid:${cid}` : baseURL
-    );
+
+    if (data) {
+      const { cid, slate, owner } = data;
+      const isActivity = this.props.carouselType === "ACTIVITY";
+      const newURL =
+        isActivity && cid ? `/${owner}/${slate.slatename}/cid:${cid}` : `${baseURL}/cid:${cid}`;
+
+      window.history.replaceState(
+        { ...window.history.state, cid: cid },
+        null,
+        cid ? newURL : baseURL
+      );
+    }
   };
 
   _handleOpen = (e) => {
@@ -187,7 +195,7 @@ export class GlobalCarousel extends React.Component {
     });
     if (this.props.carouselType === "SLATE" || this.props.carouselType === "ACTIVITY") {
       const data = this.props.objects[e.detail.index];
-      this.setWindowState(data.cid);
+      this.setWindowState(data);
     }
   };
 
@@ -212,7 +220,7 @@ export class GlobalCarousel extends React.Component {
 
     if (this.props.carouselType === "SLATE" || this.props.carouselType === "ACTIVITY") {
       const data = this.props.objects[index];
-      this.setWindowState(data.cid);
+      this.setWindowState(data);
     }
   };
 
@@ -225,7 +233,7 @@ export class GlobalCarousel extends React.Component {
 
     if (this.props.carouselType === "SLATE" || this.props.carouselType === "ACTIVITY") {
       const data = this.props.objects[index];
-      this.setWindowState(data.cid);
+      this.setWindowState(data);
     }
   };
 

--- a/components/system/components/GlobalCarousel.js
+++ b/components/system/components/GlobalCarousel.js
@@ -166,25 +166,6 @@ export class GlobalCarousel extends React.Component {
     }
   };
 
-  /* setWindowState = (cid, data) => {
-    let baseURL = window.location.pathname.split("/");
-    baseURL.length = 3;
-    baseURL = baseURL.join("/");
-
-    if (data) {
-      const { cid, slate, owner } = data;
-      const isActivity = this.props.carouselType === "ACTIVITY";
-      const newURL =
-        isActivity && cid ? `/${owner}/${slate.slatename}/cid:${cid}` : `${baseURL}/cid:${cid}`;
-
-      window.history.replaceState(
-        { ...window.history.state, cid: cid },
-        null,
-        cid ? newURL : baseURL
-      );
-    }
-  }; */
-
   setWindowState = (data) => {
     let baseURL = window.location.pathname.split("/");
     baseURL.length = 3;

--- a/components/system/components/GlobalCarousel.js
+++ b/components/system/components/GlobalCarousel.js
@@ -166,7 +166,7 @@ export class GlobalCarousel extends React.Component {
     }
   };
 
-  setWindowState = (data) => {
+  /* setWindowState = (cid, data) => {
     let baseURL = window.location.pathname.split("/");
     baseURL.length = 3;
     baseURL = baseURL.join("/");
@@ -183,6 +183,31 @@ export class GlobalCarousel extends React.Component {
         cid ? newURL : baseURL
       );
     }
+  }; */
+
+  setWindowState = (data) => {
+    let baseURL = window.location.pathname.split("/");
+    baseURL.length = 3;
+    baseURL = baseURL.join("/");
+
+    const isActivityCarousel = this.props.carouselType === "ACTIVITY";
+    if (isActivityCarousel) {
+      window.history.replaceState(
+        { ...window.history.state, cid: data && data.cid },
+        null,
+        data && data.cid
+          ? `/${data.owner}/${data.slate.slatename}/cid:${data.cid}`
+          : `/_?scene=NAV_ACTIVITY`
+      );
+
+      return;
+    }
+
+    window.history.replaceState(
+      { ...window.history.state, cid: data && data.cid },
+      null,
+      data && data.cid ? `${baseURL}/cid:${data.cid}` : baseURL
+    );
   };
 
   _handleOpen = (e) => {

--- a/components/system/components/GlobalCarousel.js
+++ b/components/system/components/GlobalCarousel.js
@@ -185,7 +185,7 @@ export class GlobalCarousel extends React.Component {
       visible: true,
       index: e.detail.index || 0,
     });
-    if (this.props.carouselType === "SLATE") {
+    if (this.props.carouselType === "SLATE" || this.props.carouselType === "ACTIVITY") {
       const data = this.props.objects[e.detail.index];
       this.setWindowState(data.cid);
     }
@@ -210,7 +210,7 @@ export class GlobalCarousel extends React.Component {
     }
     this.setState({ index });
 
-    if (this.props.carouselType === "SLATE") {
+    if (this.props.carouselType === "SLATE" || this.props.carouselType === "ACTIVITY") {
       const data = this.props.objects[index];
       this.setWindowState(data.cid);
     }
@@ -223,7 +223,7 @@ export class GlobalCarousel extends React.Component {
     }
     this.setState({ index });
 
-    if (this.props.carouselType === "SLATE") {
+    if (this.props.carouselType === "SLATE" || this.props.carouselType === "ACTIVITY") {
       const data = this.props.objects[index];
       this.setWindowState(data.cid);
     }

--- a/scenes/SceneActivity.js
+++ b/scenes/SceneActivity.js
@@ -395,7 +395,6 @@ export default class SceneActivity extends React.Component {
         };
       });
 
-    console.log(items);
     return (
       <ScenePage>
         <ScenePageHeader

--- a/scenes/SceneActivity.js
+++ b/scenes/SceneActivity.js
@@ -271,6 +271,13 @@ export default class SceneActivity extends React.Component {
 
   fetchActivityItems = async (update = false) => {
     this.setState({ loading: "loading" });
+
+    window.history.replaceState(
+      { ...window.history.state },
+      "Slate",
+      `/${this.props.viewer.username}/activity`
+    );
+
     let activity =
       this.props.tab === 0 ? this.props.viewer.activity || [] : this.props.viewer.explore || [];
     let response;

--- a/scenes/SceneActivity.js
+++ b/scenes/SceneActivity.js
@@ -271,13 +271,6 @@ export default class SceneActivity extends React.Component {
 
   fetchActivityItems = async (update = false) => {
     this.setState({ loading: "loading" });
-
-    window.history.replaceState(
-      { ...window.history.state },
-      "Slate",
-      `/${this.props.viewer.username}/activity`
-    );
-
     let activity =
       this.props.tab === 0 ? this.props.viewer.activity || [] : this.props.viewer.explore || [];
     let response;
@@ -395,8 +388,14 @@ export default class SceneActivity extends React.Component {
     let items = activity
       .filter((item) => item.data.type === "SUBSCRIBED_ADD_TO_SLATE")
       .map((item) => {
-        return { ...item.data.context.file, slate: item.data.context.slate };
+        return {
+          ...item.data.context.file,
+          slate: item.data.context.slate,
+          owner: item.data.context.user.username,
+        };
       });
+
+    console.log(items);
     return (
       <ScenePage>
         <ScenePageHeader


### PR DESCRIPTION
This PR fixes issue #521. We will now show the slate object url in the location bar on activity page when the user opens the object. This will make sharing slate easier by copying the slate object from the location bar.