### PR TITLE
Clean-up: component imports in SDS

### DIFF
--- a/components/system/index.js
+++ b/components/system/index.js
@@ -82,6 +82,8 @@ import { AvatarGroup } from "~/components/system/components/AvatarGroup";
 
 import * as SVG from "~/common/svg";
 
+import ViewSourceLink from "~/components/system/ViewSourceLink";
+
 // NOTE(jim): Export everything.
 export {
   // NOTE(martina): Actions
@@ -142,6 +144,7 @@ export {
   UL,
   OL,
   LI,
+  ViewSourceLink,
   // NOTE(jim): Fragments, not meant to be used.
   Boundary,
   DescriptionGroup,

--- a/pages/_/system/avatar-group.js
+++ b/pages/_/system/avatar-group.js
@@ -30,8 +30,7 @@ export default class SystemAvatarGroup extends React.Component {
         <br />
         <br />
         <System.P>
-          The AvatarGroup component is a compact way to show a group users or
-          contributors.
+          The AvatarGroup component is a compact way to show a group users or contributors.
         </System.P>
         <br />
         <br />
@@ -43,7 +42,7 @@ export default class SystemAvatarGroup extends React.Component {
         <br />
         <CodeBlock>
           {`import * as React from "react";
-import AvatarGroup from "~/components/system/components/AvatarGroup";`}
+import { AvatarGroup } from "slate-react-system";`}
         </CodeBlock>
         <br />
         <br />

--- a/pages/_/system/index.js
+++ b/pages/_/system/index.js
@@ -54,7 +54,7 @@ export default class SystemPageRoot extends React.Component {
         <System.P>
           You can use these components, experiences, and constants in your own React projects.
           First, install the{" "}
-          <a href="https://github.com/filecoin-project/slate-react-system" target="_blank">
+          <a href="https://www.npmjs.com/package/slate-react-system" target="_blank">
             npm module
           </a>
           :

--- a/pages/_/system/loaders.js
+++ b/pages/_/system/loaders.js
@@ -9,19 +9,13 @@ import CodeBlock from "~/components/system/CodeBlock";
 export default class SystemLoaders extends React.Component {
   render() {
     return (
-      <SystemPage
-        title="SDS: Loaders"
-        description="..."
-        url="https://slate.host/_/system/loaders"
-      >
+      <SystemPage title="SDS: Loaders" description="..." url="https://slate.host/_/system/loaders">
         <System.H1>
           Loaders <ViewSourceLink file="system/loaders.js" />
         </System.H1>
         <br />
         <br />
-        <System.P>
-          The Loader Component is used to output an animated page loader.
-        </System.P>
+        <System.P>The Loader Component is used to output an animated page loader.</System.P>
         <br />
         <br />
         <br />
@@ -39,7 +33,7 @@ export default class SystemLoaders extends React.Component {
   LoaderRotate,
   LoaderProgress,
   LoaderSpinner,
-} from "~/components/system/components/Loaders";
+} from "slate-react-system";
             `}
         </CodeBlock>
         <br />

--- a/pages/_/system/typography.js
+++ b/pages/_/system/typography.js
@@ -5,7 +5,6 @@ import * as Constants from "~/common/constants";
 import { css } from "@emotion/react";
 
 import SystemPage from "~/components/system/SystemPage";
-import ViewSourceLink from "~/components/system/ViewSourceLink";
 import CodeBlock from "~/components/system/CodeBlock";
 
 const STYLES_CSS_LABEL = css`
@@ -42,7 +41,7 @@ export default class SystemPageTypography extends React.Component {
         url="https://fps.onrender.com/system/typography"
       >
         <System.H1>
-          Typography <ViewSourceLink file="system/typography.js" />
+          Typography <System.ViewSourceLink file="system/typography.js" />
         </System.H1>
         <br />
         <br />
@@ -69,8 +68,7 @@ export default class SystemPageTypography extends React.Component {
         </System.P>
         <br />
         <CodeBlock>
-          {`import { H1, H2, H3, H4, P, UL, OL, LI } from "slate-react-system";
-import ViewSourceLink from "~/components/system/ViewSourceLink";`}
+          {`import { H1, H2, H3, H4, P, UL, OL, LI, ViewSourceLink } from "slate-react-system";`}
         </CodeBlock>
         <br />
         <br />
@@ -178,7 +176,7 @@ import ViewSourceLink from "~/components/system/ViewSourceLink";`}
           </a>
         </System.P>
         <System.P>
-          External References <ViewSourceLink file="system/typography.js" />
+          External References <System.ViewSourceLink file="system/typography.js" />
         </System.P>
         <br />
         <br />


### PR DESCRIPTION
In the examples on some of the pages of the components in the SDS, the components are imported from relative paths instead of `slate-react-system`. This PR fixes that.