### PR TITLE
increased textile storage cap for users (yay!)

### DIFF
--- a/node_common/constants.js
+++ b/node_common/constants.js
@@ -6,10 +6,10 @@ export const FILE_STORAGE_URL = "./public/static/files/";
 export const GITHUB_URL = "https://github.com/filecoin-project/slate";
 export const ANALYTICS_URL = "https://slate-stats-dev.azurewebsites.net/";
 
-// NOTE(jim): 4 GB from Ignacio
-export const TEXTILE_ACCOUNT_BYTE_LIMIT = 1073741824 * 4;
+// NOTE(toast): 30 GB from jim/martina/ignacio
+export const TEXTILE_ACCOUNT_BYTE_LIMIT = 1073741824 * 30;
 
-// NOTE(jim): 4 GB - minus .textileseed
+// NOTE(jim): 30 GB - minus .textileseed
 export const TEXTILE_BUCKET_LIMIT = TEXTILE_ACCOUNT_BYTE_LIMIT - 234;
 
 // NOTE(jim): 100mb


### PR DESCRIPTION
made it 30GB, left the 50GB on email verification message in the data meter assuming that's still true