### PR TITLE
fix: hovering on media object doesn't show actions

### DIFF
--- a/scenes/SceneFilesFolder.js
+++ b/scenes/SceneFilesFolder.js
@@ -490,6 +490,7 @@ export default class SceneFilesFolder extends React.Component {
             onUpdateViewer={this.props.onUpdateViewer}
             view={this.state.view}
             resources={this.props.resources}
+            isOwner={true}
           />
         ) : (
           <EmptyState>


### PR DESCRIPTION
Fixed a bug where when hovering the media object doesn't show the actions
<img width="763" alt="Screen Shot 2021-04-07 at 7 35 06 PM" src="https://user-images.githubusercontent.com/39884652/113923856-f42d2580-97e0-11eb-9767-28d54c7cfe7b.png">
