### PR TITLE
Confirmation popup components

### DIFF
--- a/common/user-behaviors.js
+++ b/common/user-behaviors.js
@@ -69,11 +69,6 @@ export const signOut = async ({ viewer }) => {
 
 // NOTE(jim): Permanently deletes you, forever.
 export const deleteMe = async ({ viewer }) => {
-  const message = "Do you really want to delete your account? It will be permanently removed";
-  if (!window.confirm(message)) {
-    return false;
-  }
-
   await Actions.updateSearch("delete-user");
 
   let response = await Actions.deleteViewer();

--- a/common/validations.js
+++ b/common/validations.js
@@ -193,3 +193,9 @@ export const isUnityFile = async (file) => {
     return false;
   }
 };
+
+export const isUsernameMatch = (data) => {
+  if(data.input == data.username) {
+    return true;
+  }
+}

--- a/common/validations.js
+++ b/common/validations.js
@@ -193,9 +193,3 @@ export const isUnityFile = async (file) => {
     return false;
   }
 };
-
-export const isUsernameMatch = (source, candidate) => {
-  if(source == candidate) {
-    return true;
-  }
-}

--- a/common/validations.js
+++ b/common/validations.js
@@ -194,8 +194,8 @@ export const isUnityFile = async (file) => {
   }
 };
 
-export const isUsernameMatch = (data) => {
-  if(data.input == data.username) {
+export const isUsernameMatch = (source, candidate) => {
+  if(source == candidate) {
     return true;
   }
 }

--- a/components/core/ApplicationLayout.js
+++ b/components/core/ApplicationLayout.js
@@ -51,13 +51,11 @@ const STYLES_CONTENT = css`
   }
 `;
 
-const STYLES_SIDEBAR = css`
-  z-index: ${Constants.zindex.sidebar};
+const STYLES_SIDEBAR_ELEMENTS = css`
   height: 100vh;
   width: ${Constants.sizes.sidebar}px;
   padding: 0;
   flex-shrink: 0;
-  position: fixed;
   background-color: rgba(195, 195, 196, 1);
   top: 0;
   right: 0;
@@ -66,12 +64,20 @@ const STYLES_SIDEBAR = css`
   @media (max-width: ${Constants.sizes.mobile}px) {
     width: 100%;
   }
-
+  /*
   @supports ((-webkit-backdrop-filter: blur(25px)) or (backdrop-filter: blur(25px))) {
     -webkit-backdrop-filter: blur(25px);
     backdrop-filter: blur(25px);
     background-color: rgba(195, 195, 196, 0.6);
   }
+  */
+`;
+
+const STYLES_SIDEBAR = css`
+  position: fixed;
+  top: 0; right: 0;
+  margin: auto;
+  z-index: ${Constants.zindex.sidebar};
 `;
 
 const STYLES_SIDEBAR_HEADER = css`
@@ -202,13 +208,15 @@ export default class ApplicationLayout extends React.Component {
             enabled
             onOutsideRectEvent={this._handleDismiss}
           >
-            <div
-              css={STYLES_SIDEBAR}
-              ref={(c) => {
-                this._sidebar = c;
-              }}
-            >
-              {sidebarElements}
+            <div css={STYLES_SIDEBAR}>
+              <div
+                css={STYLES_SIDEBAR_ELEMENTS}
+                ref={(c) => {
+                  this._sidebar = c;
+                }}
+              >
+                {sidebarElements}
+              </div>
             </div>
           </Boundary>
         ) : null}

--- a/components/core/ConfirmationModal.js
+++ b/components/core/ConfirmationModal.js
@@ -9,7 +9,7 @@ import { ButtonPrimaryFull, ButtonDeleteFull, ButtonDeleteDisabledFull, ButtonCa
 import { Input } from "~/components/system/components/Input.js";
 
 const STYLES_TRANSPARENT_BG = css `
-  background-color: rgba(0,0,0,0.3);
+  background-color: ${Constants.system.bgBlurGrayBlack};
   width: 100%;
   height: 100vh;
   position: fixed;
@@ -21,7 +21,7 @@ const STYLES_TRANSPARENT_BG = css `
 const STYLES_MAIN_MODAL = css `
   width: 380px;
   height: auto;
-  background-color: #fff;
+  background-color: ${Constants.system.white};
   position: fixed;
   left: 50%;
   top: 50%;
@@ -32,22 +32,21 @@ const STYLES_MAIN_MODAL = css `
 `;
 
 const STYLES_HEADER = css `
-  color: #000;
-  font-size: 16px;
-  font-weight: bold;
-  font-family: 'inter-medium', -apple-system, BlinkMacSystemFont, arial, sans-serif;
+  color: ${Constants.system.black};
+  font-size: ${Constants.typescale.lvl1};
+  font-family: ${Constants.font.semiBold};
 `;
 
 const STYLES_SUB_HEADER = css `
-  color: #8E8E93;
-  font-size: 14px;
+  color: ${Constants.system.textGray};
+  font-size: ${Constants.typescale.lvl0};
   margin-top: 16px;
-  font-family: 'inter-regular', -apple-system, BlinkMacSystemFont, arial, sans-serif;
+  font-family: ${Constants.font.text};
 `;
 
 const STYLES_INPUT_HEADER = css `
-  color: #000;
-  font-size: 12px;
+  color: ${Constants.system.black};
+  font-size: ${Constants.typescale.lvlN1};
   font-weight: bold;
   margin-top: 24px;
   margin-bottom: 8px;
@@ -57,27 +56,19 @@ export const DeleteModal = (props) => {
     let header = '';
     let subHeader = '';
 
-    if(props.data.type == 'multi') {
-      header = 'Are you sure you want to delete the selected ' + props.data.selected + ' files?';
+    if (props.data.type === 'multi') {
+      header = `Are you sure you want to delete the selected ${props.data.selected} files?`;
       subHeader = 'These files will be deleted from all connected collections and your file library. You can’t undo this action.';
     }
 
-    if(props.data.type == 'single') {
-      header = 'Are you sure you want to delete the file "' + props.data.filename + '"?';
+    if (props.data.type === 'single') {
+      header = `Are you sure you want to delete the file "${props.data.filename}"?`;
       subHeader = 'This file will be deleted from all connected collections and your file library. You can’t undo this action.';
     }
 
-    if(props.data.type == 'collection') {
-      header = 'Are you sure you want to delete the collection “' + props.data.collection + '”?';
+    if (props.data.type === 'collection') {
+      header = `Are you sure you want to delete the collection "${props.data.collection}"?`;
       subHeader = 'This collection will be deleted but all your files will remain in your file library. You can’t undo this action.';
-    }
-
-    const _handleDelete = () => {
-      props.response(true);
-    }
-
-    const _handleCancel = () => {
-      props.response(false);
     }
 
     return (
@@ -86,8 +77,8 @@ export const DeleteModal = (props) => {
           <div>
             <div css={STYLES_HEADER}>{header}</div>
             <div css={STYLES_SUB_HEADER}>{subHeader}</div>
-            <ButtonCancelFull onClick={_handleCancel} style={{ margin: '24px 0px 8px' }}>Cancel</ButtonCancelFull>
-            <ButtonDeleteFull onClick={_handleDelete}>Delete</ButtonDeleteFull>
+            <ButtonCancelFull onClick={() => props.response(false)} style={{ margin: '24px 0px 8px' }}>Cancel</ButtonCancelFull>
+            <ButtonDeleteFull onClick={() => props.response(true)}>Delete</ButtonDeleteFull>
           </div>
         </div>
       </div>
@@ -96,33 +87,20 @@ export const DeleteModal = (props) => {
 
 export const DeleteWithInputModal = (props) => {
     const [isUsernameMatch, setIsUsernameMatch] = useState(false);
-    const header = 'Are you sure you want to delete your account @' + props.data.username + '?';
+    const header = `Are you sure you want to delete your account @${props.data.username}?`;
     const subHeader = 'You will lose all your files and collections. You can’t undo this action.';
     const inputHeader = 'Please type your username to confirm';
     const inputPlaceholder = 'username';
 
-    const _handleDelete = () => {
-      props.response(true);
-    }
-
-    const _handleCancel = () => {
-      props.response(false);
-    }
-
     const _handleOnChange = (e) => {
-     if(Validations.isUsernameMatch({ input: e.target.value, username: props.data.username })) {
-      setIsUsernameMatch(true)
-     }else{
-      setIsUsernameMatch(false)
-     }
-    }
+      const match = Validations.isUsernameMatch(e.target.value, props.data.username);
+      setIsUsernameMatch(match);
+    }  
 
-    let deleteButton;
-    if(isUsernameMatch) {
-      deleteButton = <ButtonDeleteFull onClick={_handleDelete}>Delete</ButtonDeleteFull>;
-    } else {
-      deleteButton = <ButtonDeleteDisabledFull>Delete</ButtonDeleteDisabledFull>;
-    }
+    let deleteButton = <ButtonDeleteDisabledFull>Delete</ButtonDeleteDisabledFull>;
+    if (isUsernameMatch) {
+      deleteButton = <ButtonDeleteFull onClick={() => props.response(true)}>Delete</ButtonDeleteFull>;;
+    } 
 
     return (
       <div css={STYLES_TRANSPARENT_BG}>
@@ -132,7 +110,7 @@ export const DeleteWithInputModal = (props) => {
             <div css={STYLES_SUB_HEADER}>{subHeader}</div>
             <div css={STYLES_INPUT_HEADER}>{inputHeader}</div>
             <Input placeholder={inputPlaceholder} onChange={_handleOnChange} />
-            <ButtonCancelFull onClick={_handleCancel} style={{ margin: '16px 0px 8px' }}>Cancel</ButtonCancelFull>
+            <ButtonCancelFull onClick={() => props.response(false)} style={{ margin: '16px 0px 8px' }}>Cancel</ButtonCancelFull>
             {deleteButton}
           </div>
         </div>
@@ -141,16 +119,8 @@ export const DeleteWithInputModal = (props) => {
 };
 
 export const ConfirmModal = (props) => {
-    const header = 'Making this file private will remove it from the following public slates: ' + props.data.username + '. Do you wish to continue?';
+    const header = `Making this file private will remove it from the following public slates: ${props.data.username}. Do you wish to continue?`;
     const subHeader = 'Making the file private means it’s not visible to others unless they have the link.';
-
-    const _handleConfirm = () => {
-      props.response(true);
-    }
-
-    const _handleCancel = () => {
-      props.response(false);
-    }
 
     return (
       <div css={STYLES_TRANSPARENT_BG}>
@@ -158,8 +128,8 @@ export const ConfirmModal = (props) => {
           <div>
             <div css={STYLES_HEADER}>{header}</div>
             <div css={STYLES_SUB_HEADER}>{subHeader}</div>
-            <ButtonCancelFull onClick={_handleCancel} style={{ margin: '16px 0px 8px' }}>Cancel</ButtonCancelFull>
-            <ButtonPrimaryFull onClick={_handleConfirm}>Confirm</ButtonPrimaryFull>
+            <ButtonCancelFull onClick={() => props.response(false)} style={{ margin: '16px 0px 8px' }}>Cancel</ButtonCancelFull>
+            <ButtonPrimaryFull onClick={() => props.response(true)}>Confirm</ButtonPrimaryFull>
           </div>
         </div>
       </div>

--- a/components/core/ConfirmationModal.js
+++ b/components/core/ConfirmationModal.js
@@ -1,0 +1,167 @@
+import * as React from "react";
+import * as Constants from "~/common/constants";
+import * as Validations from "~/common/validations";
+
+import { css } from "@emotion/react";
+import { useState } from "react";
+
+import { ButtonPrimaryFull, ButtonDeleteFull, ButtonDeleteDisabledFull, ButtonCancelFull } from "~/components/system/components/Buttons.js";
+import { Input } from "~/components/system/components/Input.js";
+
+const STYLES_TRANSPARENT_BG = css `
+  background-color: rgba(0,0,0,0.3);
+  width: 100%;
+  height: 100vh;
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 999999;
+`;
+
+const STYLES_MAIN_MODAL = css `
+  width: 380px;
+  height: auto;
+  background-color: #fff;
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 8px;
+  padding: 24px;
+  text-align: left;
+`;
+
+const STYLES_HEADER = css `
+  color: #000;
+  font-size: 16px;
+  font-weight: bold;
+  font-family: 'inter-medium', -apple-system, BlinkMacSystemFont, arial, sans-serif;
+`;
+
+const STYLES_SUB_HEADER = css `
+  color: #8E8E93;
+  font-size: 14px;
+  margin-top: 16px;
+  font-family: 'inter-regular', -apple-system, BlinkMacSystemFont, arial, sans-serif;
+`;
+
+const STYLES_INPUT_HEADER = css `
+  color: #000;
+  font-size: 12px;
+  font-weight: bold;
+  margin-top: 24px;
+  margin-bottom: 8px;
+`;
+
+export const DeleteModal = (props) => {
+    let header = '';
+    let subHeader = '';
+
+    if(props.data.type == 'multi') {
+      header = 'Are you sure you want to delete the selected ' + props.data.selected + ' files?';
+      subHeader = 'These files will be deleted from all connected collections and your file library. You can’t undo this action.';
+    }
+
+    if(props.data.type == 'single') {
+      header = 'Are you sure you want to delete the file "' + props.data.filename + '"?';
+      subHeader = 'This file will be deleted from all connected collections and your file library. You can’t undo this action.';
+    }
+
+    if(props.data.type == 'collection') {
+      header = 'Are you sure you want to delete the collection “' + props.data.collection + '”?';
+      subHeader = 'This collection will be deleted but all your files will remain in your file library. You can’t undo this action.';
+    }
+
+    const _handleDelete = () => {
+      props.response(true);
+    }
+
+    const _handleCancel = () => {
+      props.response(false);
+    }
+
+    return (
+      <div css={STYLES_TRANSPARENT_BG}>
+        <div css={STYLES_MAIN_MODAL}>
+          <div>
+            <div css={STYLES_HEADER}>{header}</div>
+            <div css={STYLES_SUB_HEADER}>{subHeader}</div>
+            <ButtonCancelFull onClick={_handleCancel} style={{ margin: '24px 0px 8px' }}>Cancel</ButtonCancelFull>
+            <ButtonDeleteFull onClick={_handleDelete}>Delete</ButtonDeleteFull>
+          </div>
+        </div>
+      </div>
+    );
+};
+
+export const DeleteWithInputModal = (props) => {
+    const [isUsernameMatch, setIsUsernameMatch] = useState(false);
+    const header = 'Are you sure you want to delete your account @' + props.data.username + '?';
+    const subHeader = 'You will lose all your files and collections. You can’t undo this action.';
+    const inputHeader = 'Please type your username to confirm';
+    const inputPlaceholder = 'username';
+
+    const _handleDelete = () => {
+      props.response(true);
+    }
+
+    const _handleCancel = () => {
+      props.response(false);
+    }
+
+    const _handleOnChange = (e) => {
+     if(Validations.isUsernameMatch({ input: e.target.value, username: props.data.username })) {
+      setIsUsernameMatch(true)
+     }else{
+      setIsUsernameMatch(false)
+     }
+    }
+
+    let deleteButton;
+    if(isUsernameMatch) {
+      deleteButton = <ButtonDeleteFull onClick={_handleDelete}>Delete</ButtonDeleteFull>;
+    } else {
+      deleteButton = <ButtonDeleteDisabledFull>Delete</ButtonDeleteDisabledFull>;
+    }
+
+    return (
+      <div css={STYLES_TRANSPARENT_BG}>
+        <div css={STYLES_MAIN_MODAL}>
+          <div>
+            <div css={STYLES_HEADER}>{header}</div>
+            <div css={STYLES_SUB_HEADER}>{subHeader}</div>
+            <div css={STYLES_INPUT_HEADER}>{inputHeader}</div>
+            <Input placeholder={inputPlaceholder} onChange={_handleOnChange} />
+            <ButtonCancelFull onClick={_handleCancel} style={{ margin: '16px 0px 8px' }}>Cancel</ButtonCancelFull>
+            {deleteButton}
+          </div>
+        </div>
+      </div>
+    );
+};
+
+export const ConfirmModal = (props) => {
+    const header = 'Making this file private will remove it from the following public slates: ' + props.data.username + '. Do you wish to continue?';
+    const subHeader = 'Making the file private means it’s not visible to others unless they have the link.';
+
+    const _handleConfirm = () => {
+      props.response(true);
+    }
+
+    const _handleCancel = () => {
+      props.response(false);
+    }
+
+    return (
+      <div css={STYLES_TRANSPARENT_BG}>
+        <div css={STYLES_MAIN_MODAL}>
+          <div>
+            <div css={STYLES_HEADER}>{header}</div>
+            <div css={STYLES_SUB_HEADER}>{subHeader}</div>
+            <ButtonCancelFull onClick={_handleCancel} style={{ margin: '16px 0px 8px' }}>Cancel</ButtonCancelFull>
+            <ButtonPrimaryFull onClick={_handleConfirm}>Confirm</ButtonPrimaryFull>
+          </div>
+        </div>
+      </div>
+    );
+};

--- a/components/core/ConfirmationModal.js
+++ b/components/core/ConfirmationModal.js
@@ -10,12 +10,12 @@ import { Boundary } from "~/components/system/components/fragments/Boundary.js";
 
 const STYLES_TRANSPARENT_BG = css `
   background-color: ${Constants.system.bgBlurGrayBlack};
-  width: 100%;
+  z-index: ${Constants.zindex.modal};
+  width: 100vw;
   height: 100vh;
   position: fixed;
   left: 0;
   top: 0;
-  z-index: 999999;
 `;
 
 const STYLES_MAIN_MODAL = css `

--- a/components/core/ConfirmationModal.js
+++ b/components/core/ConfirmationModal.js
@@ -1,12 +1,12 @@
 import * as React from "react";
 import * as Constants from "~/common/constants";
-import * as Validations from "~/common/validations";
 
 import { css } from "@emotion/react";
 import { useState } from "react";
 
-import { ButtonPrimaryFull, ButtonDeleteFull, ButtonDeleteDisabledFull, ButtonCancelFull } from "~/components/system/components/Buttons.js";
+import { ButtonPrimaryFull, ButtonSecondaryFull, ButtonWarningFull } from "~/components/system/components/Buttons.js";
 import { Input } from "~/components/system/components/Input.js";
+import { Boundary } from "~/components/system/components/fragments/Boundary.js";
 
 const STYLES_TRANSPARENT_BG = css `
   background-color: ${Constants.system.bgBlurGrayBlack};
@@ -19,9 +19,9 @@ const STYLES_TRANSPARENT_BG = css `
 `;
 
 const STYLES_MAIN_MODAL = css `
+  background-color: ${Constants.system.white};
   width: 380px;
   height: auto;
-  background-color: ${Constants.system.white};
   position: fixed;
   left: 50%;
   top: 50%;
@@ -40,98 +40,89 @@ const STYLES_HEADER = css `
 const STYLES_SUB_HEADER = css `
   color: ${Constants.system.textGray};
   font-size: ${Constants.typescale.lvl0};
-  margin-top: 16px;
   font-family: ${Constants.font.text};
+  margin-top: 16px;
 `;
 
 const STYLES_INPUT_HEADER = css `
   color: ${Constants.system.black};
   font-size: ${Constants.typescale.lvlN1};
+  font-family: ${Constants.font.semiBold};
   font-weight: bold;
   margin-top: 24px;
   margin-bottom: 8px;
 `;
 
-export const DeleteModal = (props) => {
-    let header = '';
-    let subHeader = '';
+export const ConfirmationModal = (props) => {
+  const [isEnabled, setIsEnabled] = useState(false);
 
-    if (props.data.type === 'multi') {
-      header = `Are you sure you want to delete the selected ${props.data.selected} files?`;
-      subHeader = 'These files will be deleted from all connected collections and your file library. You can’t undo this action.';
-    }
+  const lang = {
+    deleteText: 'Delete',
+    confirmText: 'Confirm',
+    cancelText: 'Cancel'
+  }
 
-    if (props.data.type === 'single') {
-      header = `Are you sure you want to delete the file "${props.data.filename}"?`;
-      subHeader = 'This file will be deleted from all connected collections and your file library. You can’t undo this action.';
-    }
-
-    if (props.data.type === 'collection') {
-      header = `Are you sure you want to delete the collection "${props.data.collection}"?`;
-      subHeader = 'This collection will be deleted but all your files will remain in your file library. You can’t undo this action.';
-    }
-
-    return (
-      <div css={STYLES_TRANSPARENT_BG}>
-        <div css={STYLES_MAIN_MODAL}>
-          <div>
-            <div css={STYLES_HEADER}>{header}</div>
-            <div css={STYLES_SUB_HEADER}>{subHeader}</div>
-            <ButtonCancelFull onClick={() => props.response(false)} style={{ margin: '24px 0px 8px' }}>Cancel</ButtonCancelFull>
-            <ButtonDeleteFull onClick={() => props.response(true)}>Delete</ButtonDeleteFull>
-          </div>
-        </div>
-      </div>
-    );
-};
-
-export const DeleteWithInputModal = (props) => {
-    const [isUsernameMatch, setIsUsernameMatch] = useState(false);
-    const header = `Are you sure you want to delete your account @${props.data.username}?`;
-    const subHeader = 'You will lose all your files and collections. You can’t undo this action.';
-    const inputHeader = 'Please type your username to confirm';
-    const inputPlaceholder = 'username';
-
-    const _handleOnChange = (e) => {
-      const match = Validations.isUsernameMatch(e.target.value, props.data.username);
-      setIsUsernameMatch(match);
-    }  
-
-    let deleteButton = <ButtonDeleteDisabledFull>Delete</ButtonDeleteDisabledFull>;
-    if (isUsernameMatch) {
-      deleteButton = <ButtonDeleteFull onClick={() => props.response(true)}>Delete</ButtonDeleteFull>;;
+  const _handleChange = (e) => {
+    if (e.target.value === props.matchValue) {
+      setIsEnabled(true); 
+      return; 
     } 
+    setIsEnabled(false); 
+  }
 
-    return (
-      <div css={STYLES_TRANSPARENT_BG}>
+  let deleteButton = <ButtonWarningFull disabled={true}>{props.buttonText || lang.deleteText}</ButtonWarningFull>;
+  if (isEnabled) {
+    deleteButton = <ButtonWarningFull onClick={() => props.callback(true)}>{props.buttonText || lang.deleteText}</ButtonWarningFull>;
+  } 
+
+  let confirmButton = <ButtonPrimaryFull disabled={true}>{props.buttonText || lang.confirmText}</ButtonPrimaryFull>;
+  if (isEnabled) {
+    confirmButton = <ButtonPrimaryFull onClick={() => props.callback(true)}>{props.buttonText || lang.confirmText}</ButtonPrimaryFull>;
+  } 
+
+  return (
+    <div css={STYLES_TRANSPARENT_BG}>
+      <Boundary enabled={true} onOutsideRectEvent={() => props.callback(false)}>
         <div css={STYLES_MAIN_MODAL}>
-          <div>
-            <div css={STYLES_HEADER}>{header}</div>
-            <div css={STYLES_SUB_HEADER}>{subHeader}</div>
-            <div css={STYLES_INPUT_HEADER}>{inputHeader}</div>
-            <Input placeholder={inputPlaceholder} onChange={_handleOnChange} />
-            <ButtonCancelFull onClick={() => props.response(false)} style={{ margin: '16px 0px 8px' }}>Cancel</ButtonCancelFull>
-            {deleteButton}
-          </div>
-        </div>
-      </div>
-    );
-};
+          <div css={STYLES_HEADER}>{props.header}</div>
+          <div css={STYLES_SUB_HEADER}>{props.subHeader}</div>
+          {props.type === "DELETE" &&
+            <>
+              {props.withValidation ? (
+                <>
+                  <div css={STYLES_INPUT_HEADER}>{props.inputHeader}</div>
+                  <Input placeholder={props.inputPlaceholder} onChange={_handleChange} />
+                  <ButtonSecondaryFull onClick={() => props.callback(false)} style={{margin: '24px 0px 8px'}}>{lang.cancelText}</ButtonSecondaryFull>
+                  {deleteButton}
+                </>
+              ) : (
+                <>
+                  <ButtonSecondaryFull onClick={() => props.callback(false)} style={{ margin: '24px 0px 8px' }}>{lang.cancelText}</ButtonSecondaryFull>
+                  <ButtonWarningFull onClick={() => props.callback(true)}>{props.buttonText || lang.deleteText}</ButtonWarningFull>
+                </>
+              )}
+            </>
+          }
 
-export const ConfirmModal = (props) => {
-    const header = `Making this file private will remove it from the following public slates: ${props.data.username}. Do you wish to continue?`;
-    const subHeader = 'Making the file private means it’s not visible to others unless they have the link.';
-
-    return (
-      <div css={STYLES_TRANSPARENT_BG}>
-        <div css={STYLES_MAIN_MODAL}>
-          <div>
-            <div css={STYLES_HEADER}>{header}</div>
-            <div css={STYLES_SUB_HEADER}>{subHeader}</div>
-            <ButtonCancelFull onClick={() => props.response(false)} style={{ margin: '16px 0px 8px' }}>Cancel</ButtonCancelFull>
-            <ButtonPrimaryFull onClick={() => props.response(true)}>Confirm</ButtonPrimaryFull>
-          </div>
+          {props.type === "CONFIRM" &&
+            <>
+              {props.withValidation ? (
+                <>
+                  <div css={STYLES_INPUT_HEADER}>{props.inputHeader}</div>
+                  <Input placeholder={props.inputPlaceholder} onChange={_handleChange} />
+                  <ButtonSecondaryFull onClick={() => props.callback(false)} style={{ margin: '24px 0px 8px' }}>{lang.cancelText}</ButtonSecondaryFull>
+                  {confirmButton}
+                </>
+              ) : (
+                <>
+                  <ButtonSecondaryFull onClick={() => props.callback(false)} style={{ margin: '24px 0px 8px' }}>{lang.cancelText}</ButtonSecondaryFull>
+                  <ButtonPrimaryFull onClick={() => props.callback(true)}>{props.buttonText || lang.confirmText}</ButtonPrimaryFull>
+                </>
+              )}
+            </>
+          }
         </div>
-      </div>
-    );
+      </Boundary>
+    </div>
+  );
 };

--- a/components/sidebars/SidebarSingleSlateSettings.js
+++ b/components/sidebars/SidebarSingleSlateSettings.js
@@ -10,6 +10,7 @@ import * as UserBehaviors from "~/common/user-behaviors";
 
 import { RadioGroup } from "~/components/system/components/RadioGroup";
 import { css } from "@emotion/react";
+import { ConfirmationModal } from "~/components/core/ConfirmationModal";
 
 const SIZE_LIMIT = 1000000;
 const DEFAULT_IMAGE =
@@ -52,6 +53,7 @@ export default class SidebarSingleSlateSettings extends React.Component {
     name: this.props.data.data.name,
     tags: this.props.data.data?.tags || [],
     suggestions: this.props.viewer?.tags || [],
+    modalShow: false,
   };
 
   componentDidMount = () => {
@@ -107,12 +109,9 @@ export default class SidebarSingleSlateSettings extends React.Component {
     });
   };
 
-  _handleDelete = async (e) => {
-    if (
-      !window.confirm(
-        "Are you sure you want to delete this Collection? This action is irreversible."
-      )
-    ) {
+  _handleDelete = async (res) => {
+    if (!res) {
+      this.setState({ modalShow: false })
       return;
     }
 
@@ -130,6 +129,8 @@ export default class SidebarSingleSlateSettings extends React.Component {
     if (Events.hasError(response)) {
       return;
     }
+
+    this.setState({ modalShow: false })
   };
 
   render() {
@@ -303,11 +304,21 @@ export default class SidebarSingleSlateSettings extends React.Component {
           </System.ButtonPrimary>
 
           <div style={{ marginTop: 16 }}>
-            <System.ButtonWarning full onClick={this._handleDelete} style={{ overflow: "hidden" }}>
+            <System.ButtonWarning full onClick={() => this.setState({ modalShow: true })} style={{ overflow: "hidden" }}>
               Delete collection
             </System.ButtonWarning>
           </div>
         </div>
+
+        {this.state.modalShow && (
+          <ConfirmationModal 
+            type={"DELETE"}
+            withValidation={false}
+            callback={this._handleDelete} 
+            header={`Are you sure you want to delete the collection?`}
+            subHeader={`This collection will be deleted but all your files will remain in your file library. You can’t undo this action.`}
+          />
+        )}
       </React.Fragment>
     );
   }

--- a/components/sidebars/SidebarSingleSlateSettings.js
+++ b/components/sidebars/SidebarSingleSlateSettings.js
@@ -309,13 +309,12 @@ export default class SidebarSingleSlateSettings extends React.Component {
             </System.ButtonWarning>
           </div>
         </div>
-
         {this.state.modalShow && (
           <ConfirmationModal 
             type={"DELETE"}
             withValidation={false}
             callback={this._handleDelete} 
-            header={`Are you sure you want to delete the collection?`}
+            header={`Are you sure you want to delete the collection “${this.state.slatename}”?`}
             subHeader={`This collection will be deleted but all your files will remain in your file library. You can’t undo this action.`}
           />
         )}

--- a/components/system/components/Buttons.js
+++ b/components/system/components/Buttons.js
@@ -39,6 +39,13 @@ const STYLES_BUTTON_PRIMARY = css`
   }
 `;
 
+const STYLES_BUTTON_PRIMARY_DISABLED = css `
+  ${STYLES_BUTTON}
+  cursor: not-allowed;
+  background-color: ${Constants.system.bgBlue};
+  color: ${Constants.system.white};
+`;
+
 const STYLES_BUTTON_PRIMARY_TRANSPARENT = css`
   ${STYLES_BUTTON}
   cursor: pointer;
@@ -71,6 +78,17 @@ export const ButtonPrimary = (props) => {
     );
   }
 
+  if (props.disabled) {
+    return(
+      <button
+        css={STYLES_BUTTON_PRIMARY_DISABLED}
+        style={{ width: props.full ? "100%" : "auto", ...props.style }}
+        onClick={props.onClick}
+        children={props.children}
+      />
+    );
+  }
+
   return (
     <button
       css={props.transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY}
@@ -88,12 +106,12 @@ export const ButtonPrimaryFull = (props) => {
 const STYLES_BUTTON_SECONDARY = css`
   ${STYLES_BUTTON}
   cursor: pointer;
-  color: ${Constants.system.brand};
-  background-color: ${Constants.system.white};
+  color: ${Constants.system.black};
+  background-color: ${Constants.system.gray20};
   box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
 
   :hover {
-    background-color: #fcfcfc;
+    background-color: ${Constants.system.gray30};
   }
 
   :focus {
@@ -132,7 +150,7 @@ export const ButtonSecondary = (props) => {
         htmlFor={props.htmlFor}
       />
     );
-  }
+  } 
 
   return (
     <button
@@ -251,18 +269,26 @@ export const ButtonDisabledFull = (props) => {
 const STYLES_BUTTON_WARNING = css`
   ${STYLES_BUTTON}
   cursor: pointer;
-  color: ${Constants.system.red};
-  background-color: ${Constants.system.white};
+  color: ${Constants.system.white};
+  background-color: ${Constants.system.red};
   box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
 
   :hover {
-    background-color: #fcfcfc;
+    background-color: #b51111;
   }
 
   :focus {
     outline: 0;
     border: 0;
   }
+`;
+
+const STYLES_BUTTON_WARNING_DISABLED = css`
+  ${STYLES_BUTTON}
+  cursor: not-allowed;
+  color: ${Constants.system.white};
+  background-color: ${Constants.system.bgRed};
+  box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
 `;
 
 const STYLES_BUTTON_WARNING_TRANSPARENT = css`
@@ -297,6 +323,17 @@ export const ButtonWarning = (props) => {
     );
   }
 
+  if (props.disabled) {
+    return (
+      <button
+        css={STYLES_BUTTON_WARNING_DISABLED}
+        style={{ width: props.full ? "100%" : "auto", ...props.style }}
+        onClick={props.onClick}
+        children={props.children}
+      />
+  );
+  }
+
   return (
     <button
       css={props.transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING}
@@ -307,142 +344,6 @@ export const ButtonWarning = (props) => {
   );
 };
 
-
-const STYLES_BUTTON_DELETE = css`
-  ${STYLES_BUTTON}
-  cursor: pointer;
-  color: ${Constants.system.white};
-  background-color: ${Constants.system.red};
-  box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
-
-  :hover {
-    background-color: #b51111;
-  }
-
-  :focus {
-    outline: 0;
-    border: 0;
-  }
-`;
-
-const STYLES_BUTTON_DELETE_TRANSPARENT = css`
-  ${STYLES_BUTTON}
-  cursor: pointer;
-  background-color: transparent;
-  color: ${Constants.system.darkGray};
-`;
-
-export const ButtonDelete = (props) => {
-  if (props.loading) {
-    return (
-      <button
-        css={props.transparent ? STYLES_BUTTON_DELETE_TRANSPARENT : STYLES_BUTTON_DELETE}
-        style={{ width: props.full ? "100%" : "auto", ...props.style }}
-      >
-        <LoaderSpinner style={{ height: 16, width: 16 }} />
-      </button>
-    );
-  }
-
-  if (props.type === "label") {
-    return (
-      <label
-        css={props.transparent ? STYLES_BUTTON_DELETE_TRANSPARENT : STYLES_BUTTON_DELETE}
-        style={{ width: props.full ? "100%" : "auto", ...props.style }}
-        onClick={props.onClick}
-        children={props.children}
-        type={props.label}
-        htmlFor={props.htmlFor}
-      />
-    );
-  }
-
-  return (
-    <button
-      css={props.transparent ? STYLES_BUTTON_DELETE_TRANSPARENT : STYLES_BUTTON_DELETE}
-      onClick={props.onClick}
-      children={props.children}
-      style={{ width: props.full ? "100%" : "auto", ...props.style }}
-    />
-  );
-};
-
-export const ButtonDeleteFull = (props) => {
-  return <ButtonDelete full {...props} />;
-};
-
-const STYLES_BUTTON_DELETE_DISABLED = css`
-  ${STYLES_BUTTON}
-  cursor: not-allowed;
-  background-color: ${Constants.system.bgRed};
-  color: ${Constants.system.white};
-  box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
-
-  :focus {
-    outline: 0;
-    border: 0;
-  }
-`;
-
-const STYLES_BUTTON_DELETE_DISABLED_TRANSPARENT = css`
-  ${STYLES_BUTTON}
-  cursor: not-allowed;
-  background-color: transparent;
-  color: ${Constants.system.gray};
-`;
-
-export const ButtonDeleteDisabled = (props) => {
-  return (
-    <button
-      css={props.transparent ? STYLES_BUTTON_DELETE_DISABLED_TRANSPARENT : STYLES_BUTTON_DELETE_DISABLED}
-      onClick={props.onClick}
-      children={props.children}
-      type={props.label}
-      htmlFor={props.htmlFor}
-      style={{ width: props.full ? "100%" : "auto", ...props.style }}
-    />
-  );
-};
-
-export const ButtonDeleteDisabledFull = (props) => {
-  return <ButtonDeleteDisabled full {...props} />;
-};
-
-const STYLES_BUTTON_CANCEL = css`
-  ${STYLES_BUTTON}
-  cursor: pointer;
-  color: ${Constants.system.black};
-  background-color: ${Constants.system.gray20};
-  box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
-
-  :hover {
-    background-color: ${Constants.system.gray30};
-  }
-
-  :focus {
-    outline: 0;
-    border: 0;
-  }
-`;
-
-const STYLES_BUTTON_CANCEL_TRANSPARENT = css`
-  ${STYLES_BUTTON}
-  cursor: pointer;
-  background-color: transparent;
-  color: ${Constants.system.darkGray};
-`;
-
-export const ButtonCancel = (props) => {
-  return (
-    <button
-      css={props.transparent ? STYLES_BUTTON_CANCEL_TRANSPARENT : STYLES_BUTTON_CANCEL}
-      onClick={props.onClick}
-      children={props.children}
-      style={{ width: props.full ? "100%" : "auto", ...props.style }}
-    />
-  );
-};
-
-export const ButtonCancelFull = (props) => {
-  return <ButtonCancel full {...props} />;
+export const ButtonWarningFull = (props) => {
+  return <ButtonWarning full {...props} />;
 };

--- a/components/system/components/Buttons.js
+++ b/components/system/components/Buttons.js
@@ -39,7 +39,7 @@ const STYLES_BUTTON_PRIMARY = css`
   }
 `;
 
-const STYLES_BUTTON_PRIMARY_DISABLED = css `
+const STYLES_BUTTON_PRIMARY_DISABLED = css`
   ${STYLES_BUTTON}
   cursor: not-allowed;
   background-color: ${Constants.system.bgBlue};
@@ -79,7 +79,7 @@ export const ButtonPrimary = (props) => {
   }
 
   if (props.disabled) {
-    return(
+    return (
       <button
         css={STYLES_BUTTON_PRIMARY_DISABLED}
         style={{ width: props.full ? "100%" : "auto", ...props.style }}
@@ -150,7 +150,7 @@ export const ButtonSecondary = (props) => {
         htmlFor={props.htmlFor}
       />
     );
-  } 
+  }
 
   return (
     <button
@@ -271,7 +271,6 @@ const STYLES_BUTTON_WARNING = css`
   cursor: pointer;
   color: ${Constants.system.white};
   background-color: ${Constants.system.red};
-  box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
 
   :hover {
     background-color: #b51111;
@@ -331,7 +330,7 @@ export const ButtonWarning = (props) => {
         onClick={props.onClick}
         children={props.children}
       />
-  );
+    );
   }
 
   return (

--- a/components/system/components/Buttons.js
+++ b/components/system/components/Buttons.js
@@ -306,3 +306,143 @@ export const ButtonWarning = (props) => {
     />
   );
 };
+
+
+const STYLES_BUTTON_DELETE = css`
+  ${STYLES_BUTTON}
+  cursor: pointer;
+  color: ${Constants.system.white};
+  background-color: ${Constants.system.red};
+  box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
+
+  :hover {
+    background-color: #b51111;
+  }
+
+  :focus {
+    outline: 0;
+    border: 0;
+  }
+`;
+
+const STYLES_BUTTON_DELETE_TRANSPARENT = css`
+  ${STYLES_BUTTON}
+  cursor: pointer;
+  background-color: transparent;
+  color: ${Constants.system.darkGray};
+`;
+
+export const ButtonDelete = (props) => {
+  if (props.loading) {
+    return (
+      <button
+        css={props.transparent ? STYLES_BUTTON_DELETE_TRANSPARENT : STYLES_BUTTON_DELETE}
+        style={{ width: props.full ? "100%" : "auto", ...props.style }}
+      >
+        <LoaderSpinner style={{ height: 16, width: 16 }} />
+      </button>
+    );
+  }
+
+  if (props.type === "label") {
+    return (
+      <label
+        css={props.transparent ? STYLES_BUTTON_DELETE_TRANSPARENT : STYLES_BUTTON_DELETE}
+        style={{ width: props.full ? "100%" : "auto", ...props.style }}
+        onClick={props.onClick}
+        children={props.children}
+        type={props.label}
+        htmlFor={props.htmlFor}
+      />
+    );
+  }
+
+  return (
+    <button
+      css={props.transparent ? STYLES_BUTTON_DELETE_TRANSPARENT : STYLES_BUTTON_DELETE}
+      onClick={props.onClick}
+      children={props.children}
+      style={{ width: props.full ? "100%" : "auto", ...props.style }}
+    />
+  );
+};
+
+export const ButtonDeleteFull = (props) => {
+  return <ButtonDelete full {...props} />;
+};
+
+const STYLES_BUTTON_DELETE_DISABLED = css`
+  ${STYLES_BUTTON}
+  cursor: not-allowed;
+  background-color: ${Constants.system.bgRed};
+  color: ${Constants.system.white};
+  box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
+
+  :focus {
+    outline: 0;
+    border: 0;
+  }
+`;
+
+const STYLES_BUTTON_DELETE_DISABLED_TRANSPARENT = css`
+  ${STYLES_BUTTON}
+  cursor: not-allowed;
+  background-color: transparent;
+  color: ${Constants.system.gray};
+`;
+
+export const ButtonDeleteDisabled = (props) => {
+  return (
+    <button
+      css={props.transparent ? STYLES_BUTTON_DELETE_DISABLED_TRANSPARENT : STYLES_BUTTON_DELETE_DISABLED}
+      onClick={props.onClick}
+      children={props.children}
+      type={props.label}
+      htmlFor={props.htmlFor}
+      style={{ width: props.full ? "100%" : "auto", ...props.style }}
+    />
+  );
+};
+
+export const ButtonDeleteDisabledFull = (props) => {
+  return <ButtonDeleteDisabled full {...props} />;
+};
+
+const STYLES_BUTTON_CANCEL = css`
+  ${STYLES_BUTTON}
+  cursor: pointer;
+  color: ${Constants.system.black};
+  background-color: ${Constants.system.gray20};
+  box-shadow: 0 0 0 1px ${Constants.system.bgGray} inset;
+
+  :hover {
+    background-color: ${Constants.system.gray30};
+  }
+
+  :focus {
+    outline: 0;
+    border: 0;
+  }
+`;
+
+const STYLES_BUTTON_CANCEL_TRANSPARENT = css`
+  ${STYLES_BUTTON}
+  cursor: pointer;
+  background-color: transparent;
+  color: ${Constants.system.darkGray};
+`;
+
+export const ButtonCancel = (props) => {
+  return (
+    <button
+      css={props.transparent ? STYLES_BUTTON_CANCEL_TRANSPARENT : STYLES_BUTTON_CANCEL}
+      onClick={props.onClick}
+      children={props.children}
+      style={{ width: props.full ? "100%" : "auto", ...props.style }}
+    />
+  );
+};
+
+export const ButtonCancelFull = (props) => {
+  return <ButtonCancel full {...props} />;
+};

--- a/scenes/SceneEditAccount.js
+++ b/scenes/SceneEditAccount.js
@@ -15,6 +15,7 @@ import { SecondaryTabGroup } from "~/components/core/TabGroup";
 import ScenePage from "~/components/core/ScenePage";
 import ScenePageHeader from "~/components/core/ScenePageHeader";
 import Avatar from "~/components/core/Avatar";
+import { ConfirmationModal } from "~/components/core/ConfirmationModal";
 
 const STYLES_FILE_HIDDEN = css`
   height: 1px;
@@ -56,6 +57,7 @@ export default class SceneEditAccount extends React.Component {
     savingNameBio: false,
     changingFilecoin: false,
     tab: 0,
+    modalShow: false,
   };
 
   _handleUpload = async (e) => {
@@ -151,13 +153,19 @@ export default class SceneEditAccount extends React.Component {
     this.setState({ changingPassword: false, password: "", confirm: "" });
   };
 
-  _handleDelete = async (e) => {
+  _handleDelete = async (res) => {
+    if (!res) {
+      this.setState({ modalShow: false });
+      return;
+    }
     this.setState({ deleting: true });
-
+    this.setState({ modalShow: false });
+    
     await Window.delay(100);
 
     await UserBehaviors.deleteMe({ viewer: this.props.viewer });
     this.setState({ deleting: false });
+
   };
 
   _handleChange = (e) => {
@@ -333,7 +341,7 @@ export default class SceneEditAccount extends React.Component {
 
             <div style={{ marginTop: 24 }}>
               <System.ButtonWarning
-                onClick={this._handleDelete}
+                onClick={() => this.setState({ modalShow: true })}
                 loading={this.state.deleting}
                 style={{ width: "200px" }}
               >
@@ -351,6 +359,19 @@ export default class SceneEditAccount extends React.Component {
           tabIndex="-1"
           css={STYLES_COPY_INPUT}
         />{" "}
+
+        {this.state.modalShow && (
+        <ConfirmationModal 
+          type={"DELETE"}
+          withValidation={true}
+          matchValue={this.state.username}
+          callback={this._handleDelete} 
+          header={`Are you sure you want to delete your account @${this.state.username}?`}
+          subHeader={`You will lose all your files and collections. You can’t undo this action.`}
+          inputHeader={`Please type your username to confirm`}
+          inputPlaceholder={`username`}
+        />
+      )}
       </ScenePage>
     );
   }

--- a/scenes/SceneSettingsDeveloper.js
+++ b/scenes/SceneSettingsDeveloper.js
@@ -140,13 +140,13 @@ export default class SceneSettingsDeveloper extends React.Component {
   };
 
   _handleDelete = async (id) => {
-    this.setState({ loading: true });
+    this.setState({ loading: true, modalShow: false });
 
     const response = await Actions.deleteAPIKey({ id });
 
     Events.hasError(response);
 
-    this.setState({ loading: false, modalShow: false });
+    this.setState({ loading: false });
   };
 
   _handleChangeLanguage = (newLanguage) => {


### PR DESCRIPTION
Created two new button styles:
- delete
- cancel

Created 3 popup modal components:
- single file, multi file and collection delete
- delete with input
- confirmation

Added a new validation rule for the input value to equal a string. Used to disabled and enable the delete button.

<img width="423" alt="Screen Shot 2021-05-05 at 10 42 18 AM" src="https://user-images.githubusercontent.com/60402678/117179038-ef33a580-ad8f-11eb-8288-526d6c810e93.png">
<img width="414" alt="Screen Shot 2021-05-05 at 10 52 39 AM" src="https://user-images.githubusercontent.com/60402678/117179115-0a061a00-ad90-11eb-8509-ff036d9d5adb.png">

