### PR TITLE
Tweaks: Block Previews

### DIFF
--- a/common/styles.js
+++ b/common/styles.js
@@ -18,6 +18,7 @@ export const LINK = css`
 const TEXT = css`
   box-sizing: border-box;
   overflow-wrap: break-word;
+  text-align: left;
 
   a {
     ${LINK}

--- a/components/core/CollectionPreviewBlock/index.js
+++ b/components/core/CollectionPreviewBlock/index.js
@@ -225,7 +225,7 @@ export default function CollectionPreview({ collection, viewer, owner, onAction 
           transition={{ duration: 0.4, ease: "easeOut" }}
         >
           <div css={[Styles.HORIZONTAL_CONTAINER_CENTERED, STYLES_SPACE_BETWEEN]}>
-            <Typography.H5 color="textBlack" nbrOflines={1}>
+            <Typography.H5 color="textBlack" nbrOflines={1} title={collection.slatename}>
               {collection.slatename}
             </Typography.H5>
           </div>

--- a/components/core/DataView.js
+++ b/components/core/DataView.js
@@ -753,7 +753,6 @@ export default class DataView extends React.Component {
                                     height: 24,
                                     width: 24,
                                     borderRadius: "8px",
-                                    boxShadow: `0 0 0 1px ${Constants.system.white}`,
                                     backgroundColor: this.state.checked[i]
                                       ? Constants.system.blue
                                       : "rgba(255, 255, 255, 0.75)",

--- a/components/core/ObjectPreview/ObjectPreviewPrimitive.js
+++ b/components/core/ObjectPreview/ObjectPreviewPrimitive.js
@@ -20,22 +20,20 @@ const STYLES_WRAPPER = (theme) => css`
 `;
 
 const STYLES_DESCRIPTION = (theme) => css`
+  position: relative;
   box-shadow: 0 -0.5px 0.5px ${theme.system.grayLight4};
   border-radius: 0px 0px 16px 16px;
   box-sizing: border-box;
   width: 100%;
-  max-height: 61px;
+  background-color: ${theme.semantic.bgLight};
+  border-radius: 16px;
+  height: calc(170px + 61px);
+  padding: 9px 16px 8px;
+  z-index: 1;
 
   @media (max-width: ${theme.sizes.mobile}px) {
     padding: 8px;
   }
-`;
-
-const STYLES_DESCRIPTION_INNER = (theme) => css`
-  background-color: ${theme.semantic.bgLight};
-  padding: 9px 16px 8px;
-  border-radius: 16px;
-  height: calc(170px + 61px);
 `;
 
 const STYLES_PREVIEW = css`
@@ -73,6 +71,7 @@ export default function ObjectPreviewPrimitive({
   isImage,
   onAction,
 }) {
+  const { isDescriptionVisible, showDescription, hideDescription } = useShowDescription();
   // const { like, isLiked, likeCount } = useLikeHandler({ file, viewer });
   // const { save, isSaved, saveCount } = useSaveHandler({ file, viewer });
   // const showSaveButton = viewer?.id !== file?.ownerId;
@@ -81,11 +80,8 @@ export default function ObjectPreviewPrimitive({
   // const showControls = () => setShowControls(true);
   // const hideControls = () => setShowControls(false);
 
-  const [isBodyVisible, setShowBody] = React.useState(false);
-  const showBody = () => setShowBody(true);
-  const hideBody = () => setShowBody(false);
   const body = file?.data?.body;
-  const isLink = file.isLink;
+  const { isLink } = file;
 
   const title = file.data.name || file.filename;
 
@@ -126,17 +122,22 @@ export default function ObjectPreviewPrimitive({
           <div>{children}</div>
         </AspectRatio>
       </div>
-      <article css={STYLES_DESCRIPTION} onMouseEnter={showBody} onMouseLeave={hideBody}>
-        <motion.div
-          css={STYLES_DESCRIPTION_INNER}
+      <div style={{ maxHeight: 61 }}>
+        <motion.article
+          css={STYLES_DESCRIPTION}
+          onMouseMove={showDescription}
+          onMouseLeave={hideDescription}
           initial={{ y: 0 }}
-          animate={{ y: isBodyVisible ? -170 : 0 }}
+          animate={{
+            y: isDescriptionVisible ? -170 : 0,
+            borderRadius: isDescriptionVisible ? "16px" : "0px",
+          }}
           transition={{ type: "spring", stiffness: 170, damping: 26 }}
         >
           <H5 as="h2" nbrOflines={1} color="textBlack">
             {title}
           </H5>
-          <div style={{ marginTop: 3 }}>
+          <div style={{ marginTop: 3, display: "flex" }}>
             {typeof tag === "string" ? (
               <P3 as="small" css={STYLES_UPPERCASE} color="textGray">
                 {tag}
@@ -148,15 +149,32 @@ export default function ObjectPreviewPrimitive({
           <H5
             as={motion.p}
             initial={{ opacity: 0 }}
-            animate={{ opacity: isBodyVisible ? 1 : 0 }}
+            animate={{ opacity: isDescriptionVisible ? 1 : 0 }}
             style={{ marginTop: 5 }}
             nbrOflines={8}
             color="textGrayDark"
           >
             {body || ""}
           </H5>
-        </motion.div>
-      </article>
+        </motion.article>
+      </div>
     </div>
   );
 }
+
+const useShowDescription = () => {
+  const [isDescriptionVisible, setShowDescription] = React.useState(false);
+  const timeoutId = React.useRef();
+
+  const showDescription = () => {
+    clearTimeout(timeoutId.current);
+    const id = setTimeout(() => setShowDescription(true), 250);
+    timeoutId.current = id;
+  };
+  const hideDescription = () => {
+    clearTimeout(timeoutId.current);
+    setShowDescription(false);
+  };
+
+  return { isDescriptionVisible, showDescription, hideDescription };
+};

--- a/components/core/ObjectPreview/ObjectPreviewPrimitive.js
+++ b/components/core/ObjectPreview/ObjectPreviewPrimitive.js
@@ -134,7 +134,7 @@ export default function ObjectPreviewPrimitive({
           }}
           transition={{ type: "spring", stiffness: 170, damping: 26 }}
         >
-          <H5 as="h2" nbrOflines={1} color="textBlack">
+          <H5 as="h2" nbrOflines={1} color="textBlack" title={title}>
             {title}
           </H5>
           <div style={{ marginTop: 3, display: "flex" }}>

--- a/components/system/components/CheckBox.js
+++ b/components/system/components/CheckBox.js
@@ -17,7 +17,7 @@ const STYLES_CHECKBOX = css`
 
 const STYLES_CHECKBOX_FIGURE = css`
   box-sizing: border-box;
-  box-shadow: 0 0 0 1px ${Constants.semantic.borderGrayLight};
+  box-shadow: 0 0 0 1px ${Constants.system.grayLight4};
   background-color: ${Constants.system.white};
   border-radius: 4px;
   display: inline-flex;

--- a/node_common/data/methods/get-subscriptions-by-user-id.js
+++ b/node_common/data/methods/get-subscriptions-by-user-id.js
@@ -11,9 +11,9 @@ export default async ({ ownerId }) => {
       // const slateFiles = () =>
       //   DB.raw("json_agg(?? order by ?? asc) as ??", ["files", "slate_files.createdAt", "objects"]);
 
-      const ownerQueryFields = ["*", ...Constants.userPreviewProperties, "owner"];
+      const ownerQueryFields = [...Constants.userPreviewProperties, "owner"];
       const ownerQuery = DB.raw(
-        `??, json_build_object('id', ??, 'data', ??, 'username', ??) as ??`,
+        `json_build_object('id', ??, 'data', ??, 'username', ??) as ??`,
         ownerQueryFields
       );
 
@@ -36,7 +36,7 @@ export default async ({ ownerId }) => {
           // .orderBy("subscriptions.createdAt", "desc");
           .groupBy("slates.id")
       )
-        .select(ownerQuery)
+        .select(...Serializers.slateProperties, "objects", ownerQuery)
         .from("slates")
         .join("users", "slates.ownerId", "users.id");
 


### PR DESCRIPTION
This Pr fixes the following bugs
* Revoke new changes to the ObjectPreview's checkbox
* Add debounce on MouseMove to The Object Preview
* Show description on hover in CollectionPreview
* Fix 404 when visiting collections from the `subscribed` tab
* Add title prop to Previews