### PR TITLE
Fixes: visual bugs across browsers

### DIFF
--- a/common/styles.js
+++ b/common/styles.js
@@ -19,6 +19,7 @@ const TEXT = css`
   box-sizing: border-box;
   overflow-wrap: break-word;
   text-align: left;
+  font-weight: normal;
 
   a {
     ${LINK}
@@ -26,9 +27,8 @@ const TEXT = css`
 `;
 
 export const H1 = css`
-  font-family: ${Constants.font.text};
+  font-family: ${Constants.font.medium};
   font-size: 1.953rem;
-  font-weight: medium;
   line-height: 1.5;
   letter-spacing: -0.021px;
 
@@ -36,9 +36,8 @@ export const H1 = css`
 `;
 
 export const H2 = css`
-  font-family: ${Constants.font.text};
+  font-family: ${Constants.font.medium};
   font-size: 1.563rem;
-  font-weight: medium;
   line-height: 1.5;
   letter-spacing: -0.019px;
 
@@ -46,7 +45,7 @@ export const H2 = css`
 `;
 
 export const H3 = css`
-  font-family: ${Constants.font.text};
+  font-family: ${Constants.font.medium};
   font-size: 1.25rem;
   line-height: 1.5;
   letter-spacing: -0.017px;
@@ -55,7 +54,7 @@ export const H3 = css`
 `;
 
 export const H4 = css`
-  font-family: ${Constants.font.text};
+  font-family: ${Constants.font.medium};
   font-size: 1rem;
   line-height: 1.5;
   letter-spacing: -0.011px;
@@ -64,7 +63,7 @@ export const H4 = css`
 `;
 
 export const H5 = css`
-  font-family: ${Constants.font.text};
+  font-family: ${Constants.font.medium};
   font-size: 0.875rem;
   line-height: 1.5;
   letter-spacing: -0.006px;
@@ -75,14 +74,12 @@ export const H5 = css`
 export const P1 = css`
   font-family: ${Constants.font.text};
   font-size: 1rem;
-  font-weight: regular;
   line-height: 1.5;
   letter-spacing: -0.011px;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     font-family: ${Constants.font.text};
     font-size: 0.875rem;
-    font-weight: regular;
     line-height: 1.5;
     letter-spacing: -0.006px;
   }
@@ -93,14 +90,12 @@ export const P1 = css`
 export const P2 = css`
   font-family: ${Constants.font.text};
   font-size: 0.875rem;
-  font-weight: regular;
   line-height: 1.5;
   letter-spacing: -0.006px;
 
   @media (max-width: ${Constants.sizes.mobile}px) {
     font-family: ${Constants.font.text};
     font-size: 0.75rem;
-    font-weight: normal;
     line-height: 1.3;
     letter-spacing: 0px;
   }
@@ -111,7 +106,6 @@ export const P2 = css`
 export const P3 = css`
   font-family: ${Constants.font.text};
   font-size: 0.75rem;
-  font-weight: normal;
   line-height: 1.334;
   letter-spacing: 0px;
 
@@ -121,7 +115,6 @@ export const P3 = css`
 export const C1 = css`
   font-family: ${Constants.font.code};
   font-size: 0.75rem;
-  font-weight: normal;
   line-height: 1.3;
 
   ${TEXT}
@@ -130,7 +123,6 @@ export const C1 = css`
 export const C2 = css`
   font-family: ${Constants.font.code};
   font-size: 0.875rem;
-  font-weight: normal;
   line-height: 1.5;
 
   ${TEXT}
@@ -139,16 +131,14 @@ export const C2 = css`
 export const C3 = css`
   font-family: ${Constants.font.code};
   font-size: 0.875rem;
-  font-weight: normal;
   line-height: 1.5;
 
   ${TEXT}
 `;
 
 export const B1 = css`
-  font-family: ${Constants.font.text};
+  font-family: ${Constants.font.medium};
   font-size: 0.875rem;
-  font-weight: medium;
   line-height: 1;
   letter-spacing: -0.006px;
 

--- a/components/core/CollectionPreviewBlock/index.js
+++ b/components/core/CollectionPreviewBlock/index.js
@@ -145,7 +145,7 @@ export default function CollectionPreview({ collection, viewer, owner, onAction 
           <motion.article css={STYLES_DESCRIPTION}>
             <div style={{ position: "relative", paddingTop: 9 }}>
               <H5 nbrOflines={1} style={{ visibility: "hidden" }}>
-                {title}
+                {title?.slice(0, 5)}
               </H5>
 
               {description && (
@@ -155,7 +155,7 @@ export default function CollectionPreview({ collection, viewer, owner, onAction 
                     nbrOflines={1}
                     color="textGrayDark"
                   >
-                    {description}
+                    {description?.slice(0, 5)}
                   </P3>
                 </div>
               )}

--- a/components/core/CollectionPreviewBlock/index.js
+++ b/components/core/CollectionPreviewBlock/index.js
@@ -19,7 +19,7 @@ const STYLES_CONTAINER = (theme) => css`
   display: flex;
   flex-direction: column;
   background-color: ${theme.semantic.bgLight};
-  box-shadow: 0 0 0 0.5px ${theme.system.grayLight4}, ${theme.shadow.lightSmall};
+  box-shadow: 0 0 0 1px ${theme.system.grayLight4}, ${theme.shadow.lightSmall};
   border-radius: 16px;
   width: 100%;
   overflow: hidden;
@@ -41,7 +41,7 @@ const STYLES_INNER_DESCRIPTION = (theme) => css`
   width: 100%;
   background-color: ${theme.semantic.bgLight};
   padding: 9px 16px 0px;
-  box-shadow: 0 -0.5px 0.5px ${theme.system.grayLight4};
+  box-shadow: 0 -0.5px 1px ${theme.system.grayLight4};
 `;
 
 const STYLES_SPACE_BETWEEN = css`

--- a/components/core/CollectionPreviewBlock/index.js
+++ b/components/core/CollectionPreviewBlock/index.js
@@ -41,7 +41,7 @@ const STYLES_INNER_DESCRIPTION = (theme) => css`
   width: 100%;
   background-color: ${theme.semantic.bgLight};
   padding: 9px 16px 0px;
-  box-shadow: 0 -0.5px 1px ${theme.system.grayLight4};
+  border-top: 1px solid ${theme.system.grayLight4};
 `;
 
 const STYLES_SPACE_BETWEEN = css`

--- a/components/core/ObjectPreview/ObjectPreviewPrimitive.js
+++ b/components/core/ObjectPreview/ObjectPreviewPrimitive.js
@@ -150,7 +150,7 @@ export default function ObjectPreviewPrimitive({
           <motion.article css={STYLES_DESCRIPTION}>
             <div style={{ position: "relative", paddingTop: 9 }}>
               <H5 as="h2" nbrOflines={1} style={{ visibility: "hidden" }}>
-                {title}
+                {title?.slice(0, 5)}
               </H5>
 
               {description && (
@@ -160,7 +160,7 @@ export default function ObjectPreviewPrimitive({
                     nbrOflines={1}
                     color="textGrayDark"
                   >
-                    {description}
+                    {description?.slice(0, 5)}
                   </P3>
                 </div>
               )}

--- a/components/core/ObjectPreview/ObjectPreviewPrimitive.js
+++ b/components/core/ObjectPreview/ObjectPreviewPrimitive.js
@@ -37,7 +37,7 @@ const STYLES_INNER_DESCRIPTION = (theme) => css`
   width: 100%;
   background-color: ${theme.semantic.bgLight};
   padding: 9px 16px 0px;
-  box-shadow: 0 -0.5px 1px ${theme.system.grayLight4};
+  border-top: 1px solid ${theme.system.grayLight4};
 `;
 
 const STYLES_TAG = css`

--- a/components/core/ObjectPreview/ObjectPreviewPrimitive.js
+++ b/components/core/ObjectPreview/ObjectPreviewPrimitive.js
@@ -15,7 +15,7 @@ const STYLES_WRAPPER = (theme) => css`
   position: relative;
   background-color: ${theme.semantic.bgLight};
   transition: box-shadow 0.2s;
-  box-shadow: 0 0 0 0.5px ${theme.system.grayLight4}, ${theme.shadow.card};
+  box-shadow: 0 0 0 1px ${theme.system.grayLight4}, ${theme.shadow.card};
   border-radius: 16px;
   overflow: hidden;
   cursor: pointer;
@@ -37,7 +37,7 @@ const STYLES_INNER_DESCRIPTION = (theme) => css`
   width: 100%;
   background-color: ${theme.semantic.bgLight};
   padding: 9px 16px 0px;
-  box-shadow: 0 -0.5px 0.5px ${theme.system.grayLight4};
+  box-shadow: 0 -0.5px 1px ${theme.system.grayLight4};
 `;
 
 const STYLES_TAG = css`


### PR DESCRIPTION
* Fixed a bug where an object description overflowed (safari only)
![image](https://user-images.githubusercontent.com/39884652/130132482-de006496-2342-4548-a9d4-751e1d6720f0.png)
* Small adjustment to border width, from 0.5px to 1px. For some unknow reasons it renders like this in safari
![Screen Shot 2021-08-19 at 17 34 48](https://user-images.githubusercontent.com/39884652/130132674-d1ad269e-068c-49cd-83f1-d944ad22627b.png)
* Fixed shadow overflow in description box (firefox only)
![Screen Shot 2021-08-19 at 18 22 42](https://user-images.githubusercontent.com/39884652/130132785-170a9c68-01f4-434e-9ea4-deab9bd23187.png)
* Updated font to use the correct family and weight

