### PR TITLE
Settings modal jumper

### DIFF
--- a/components/core/ApplicationUserControls.js
+++ b/components/core/ApplicationUserControls.js
@@ -13,6 +13,7 @@ import { H4, P3 } from "~/components/system/components/Typography";
 
 import ProfilePhoto from "~/components/core/ProfilePhoto";
 import DataMeter from "~/components/core/DataMeter";
+import * as Settings from "~/components/core/Settings";
 
 const STYLES_HEADER = css`
   position: relative;
@@ -210,9 +211,13 @@ export class ApplicationUserControlsPopup extends React.Component {
         {
           text: (
             <div css={STYLES_SECTION_ITEM_HOVER}>
-              <Link href={"/_/settings"} onAction={this._handleAction}>
-                Settings
-              </Link>
+              <Settings.Provider>
+                <Settings.Root viewer={this.props.viewer}>
+                  <Settings.Trigger>
+                    Settings
+                  </Settings.Trigger>
+                </Settings.Root>
+              </Settings.Provider> 
             </div>
           ),
         },

--- a/components/core/Settings/Jumper.js
+++ b/components/core/Settings/Jumper.js
@@ -1,0 +1,394 @@
+import * as React from "react";
+import * as Jumper from "~/components/core/Jumper";
+import * as System from "~/components/system";
+import * as Logging from "~/common/logging";
+import * as Strings from "~/common/strings";
+import * as Styles from "~/common/styles";
+import * as Constants from "~/common/constants";
+import * as SVG from "~/common/svg";
+import * as Validations from "~/common/validations";
+import * as Events from "~/common/custom-events";
+import * as Actions from "~/common/actions";
+import * as UserBehaviors from "~/common/user-behaviors";
+
+import { css } from "@emotion/react";
+import { useSettingsContext } from "~/components/core/Settings/Provider";
+import { AnimatePresence, motion } from "framer-motion";
+
+import ProfilePhoto from "~/components/core/ProfilePhoto";
+
+import { Input } from "~/components/system/components/Input";
+import { Textarea } from "~/components/system/components/Textarea";
+import { ButtonPrimary, ButtonSecondary } from "~/components/system/components/Buttons";
+import * as Type from "~/components/system/components/Typography";
+
+const STYLES_FLEX_ROW = `
+  display: flex;
+  flex-direction: row;
+  position: static;
+`;
+
+const STYLES_FLEX_COLUMN = `
+  display: flex;
+  flex-direction: column;
+  position: static;
+  align-items: flex-start;
+`;
+
+const STYLES_JUMPER_HEADER = css`
+  ${Styles.HORIZONTAL_CONTAINER_CENTERED};
+  padding: 17px 20px 15px;
+`;
+
+const STYLES_JUMPER_OVERLAY = (theme) => css`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: ${theme.zindex.jumper};
+  @supports ((-webkit-backdrop-filter: blur(75px)) or (backdrop-filter: blur(75px))) {
+    -webkit-backdrop-filter: blur(75px);
+    backdrop-filter: blur(75px);
+    background-color: ${theme.semantic.bgBlurLightTRN};
+  }
+`;
+
+const STYLES_JUMPER_DISMISS_BUTTON = (theme) => css`
+  ${Styles.BUTTON_RESET};
+  color: ${theme.semantic.textGray};
+`;
+
+const STYLES_JUMPER_MAIN = css`
+  ${STYLES_FLEX_ROW}
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+  height: 348px;
+  order: 1;
+`;
+
+const STYLES_JUMPER_SIDEBAR = css`
+  ${STYLES_FLEX_ROW}
+  align-items: flex-start;
+  width: 190px;
+  height: 344px;
+  padding: 20px 0px;
+  border-right: 1px solid ${Constants.system.grayLight5};
+`;
+
+const STYLES_JUMPER_CONTENT = css`
+  ${STYLES_FLEX_COLUMN}
+  align-items: flex-start;
+  width: 100%;
+  height: 340px;
+  overflow: scroll;
+  margin: 0px 20px;
+  padding-bottom: 140px;
+  padding-top: 20px;
+
+  ::-webkit-scrollbar {
+    width: 0;
+    background: transparent; 
+  }
+`;
+
+const STYLES_ACCOUNT = css`
+  ${STYLES_FLEX_COLUMN}
+  align-items: center;
+  width: 100%;
+`;
+
+const STYLES_ACCOUNT_USER = css`
+  ${STYLES_FLEX_COLUMN}
+  align-items: center;
+  margin: 10px 0px;
+`;
+
+const STYLES_ITEM_CONTAINER = css`
+  ${STYLES_FLEX_COLUMN}
+  width: 100%;
+  height: 76px;
+  margin: 20px 0px;
+`;
+
+const STYLES_ITEM_HEADER = css`
+  font-size: 12px;
+  margin-bottom: 8px;
+  color: ${Constants.system.gray};
+`;
+
+const STYLES_AVATAR_BOX = css`
+  ${STYLES_FLEX_COLUMN}
+  width: 100%;
+  height: 76px;
+`;
+
+const STYLES_AVATAR_UPLOAD = css`
+  ${STYLES_FLEX_ROW}
+  align-items: flex-end;
+`;
+
+const STYLES_EDIT_INFO_FOOTER = css`
+  display: flex;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 452px;
+  height: 50px;
+  padding: 12px 20px;
+  background-color: ${Constants.system.white};
+  border-radius: 0px 0px 16px 0px;
+  border-top: 1px solid ${Constants.system.grayLight5};
+`;
+
+const STYLES_MENU_CONTAINER = css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 16px;
+  width: 184px;
+  height: auto;
+  margin: 0px 0px;
+`;
+
+const STYLES_MENU_ITEM = css`
+  display: flex;
+  font-weight: 400;
+  font-size: 14px;
+  width: 100%;
+  height: 32px;
+  border-radius: 12px;
+  padding: 8px;
+  :hover {
+    background-color: ${Constants.system.grayLight5};
+    cursor: pointer;
+  }
+`;
+
+const STYLES_MENU_ITEM_ICON = css`
+  display:flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 16px;
+`;
+
+const Sidebar = (props) => {
+  return (
+    <div css={STYLES_JUMPER_SIDEBAR}>
+      <div css={STYLES_ACCOUNT}>
+        <ProfilePhoto
+          user={props.viewer}
+          style={{ margin: "10px 0px" }}
+          size={48}
+        />
+        <div css={STYLES_ACCOUNT_USER}>
+          <p style={{ fontWeight: "500", fontSize: "14px" }}>{props.viewer.username}</p>
+          <p style={{ fontWeight: "normal", fontSize: "12px" }}>{props.viewer.email}</p>
+        </div>
+
+        <div css={STYLES_MENU_CONTAINER}>
+          {props.tabs.map((tab, i) => {     
+             return(                 
+               <div css={STYLES_MENU_ITEM} key={i}>
+                 <div css={STYLES_MENU_ITEM_ICON}>
+                  {tab.icon}
+                </div>
+                {tab.title}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TabContent = (props) => {
+  const [state, setState] = React.useState({
+    username: props.viewer.username,
+    name: props.viewer.name,
+    body: props.viewer.body || "",
+    photo: props.viewer.photo,
+    changingAvatar: false,
+    savingNameBio: false,
+    modalShow: false,
+  });
+
+  const _handleChange = (e) => {
+    setState((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const _handleUpload = async (e) => {
+    setState((prev) => ({ ...prev, changingAvatar: true }));
+    
+    let file = await UserBehaviors.uploadImage(e.target.files[0]);
+    if (!file) {
+      setState((prev) => ({ ...prev, changingAvatar: false }));
+      return;
+    }
+
+    const cid = file.cid;
+    const url = Strings.getURLfromCID(cid);
+    
+    let updateResponse = await Actions.updateViewer({
+      user: {
+        photo: url,
+      },
+    });
+
+    Events.hasError(updateResponse);
+    setState((prev) => ({ ...prev, changingAvatar: false, photo: url }));
+  };
+
+  const _handleSave = async (e) => {
+    if (!Validations.username(state.username)) {
+      Events.dispatchMessage({
+        message: "Please include only letters and numbers in your username",
+      });
+      return;
+    }
+    /*
+    props.onAction({
+      type: "UPDATE_VIEWER",
+      viewer: { username: state.username, name: state.name, body: state.body },
+    });
+    */
+    setState((prev) => ({ ...prev, savingNameBio: true }));
+
+    let response = await Actions.updateViewer({
+      user: {
+        name: state.name,
+        photo: state.photo,
+        body: state.body,
+      },
+    });
+
+    Events.hasError(response);
+    setState((prev) => ({ ...prev, savingNameBio: false }));
+  };
+
+  return (
+    <>
+      <div css={STYLES_JUMPER_CONTENT}>
+        <div css={STYLES_AVATAR_BOX}>
+          <p css={STYLES_ITEM_HEADER}>Avatar</p>
+          <div css={STYLES_AVATAR_UPLOAD}>
+            <ProfilePhoto
+              user={state}
+              size={48}
+            />
+            <input style={{ visibility: 'hidden', width: '0px' }} type="file" id="upload-avatar" onChange={_handleUpload} />
+            <ButtonSecondary
+              style={{ marginLeft: "8px", minHeight: "24px" }}
+              type="label"
+              for="upload-avatar"
+              accept="image/png, image/jpeg, image/jpg"
+              loading={state.changingAvatar}
+            >
+              Upload
+            </ButtonSecondary>
+          </div>
+        </div>
+
+        <div css={STYLES_ITEM_CONTAINER}>
+          <p css={STYLES_ITEM_HEADER}>Display name</p>
+          <Input
+            name="name"
+            value={state.name}
+            placeholder="Your name..."
+            onChange={_handleChange}
+          />
+        </div>
+
+        <div css={STYLES_ITEM_CONTAINER}>
+          <p css={STYLES_ITEM_HEADER}>Bio</p>
+          <Textarea
+            name="body"
+            value={state.body}
+            placeholder="A bit about yourself..."
+            onChange={_handleChange}
+          />
+        </div>
+
+        <div css={STYLES_EDIT_INFO_FOOTER}>
+          <ButtonSecondary 
+            style={{ minHeight: "24px", height: "24px", marginLeft: "auto" }}
+          >
+            Cancel
+          </ButtonSecondary>
+          <ButtonPrimary
+            style={{ minHeight: "24px", height: "24px", marginLeft: '8px' }}
+            onClick={_handleSave}
+            loading={state.savingNameBio}
+          >
+            Save
+          </ButtonPrimary>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export function SettingsJumper({ data }) {
+  const [{ isSettingsJumperVisible }, { hideSettingsJumper }] = useSettingsContext();
+
+  const handleChange = (e) => {
+    setState((prev) => ({ ...prev, [e.target.name]: e.target.value, urlError: false }));
+  };
+
+  const tabs = [
+    {
+      title: 'Storage',
+      icon: <SVG.HardDrive />
+    },
+    {
+      title: 'Profile',
+      icon: <SVG.Users />
+    },
+    {
+      title: 'Theme',
+      icon: <SVG.Moon style={{ marginTop: '-4px' }} />
+    },
+    {
+      title: 'Account',
+      icon: <SVG.Settings />
+    },
+  ]
+
+  return (
+    <>
+
+      <AnimatePresence>
+        {isSettingsJumperVisible && (
+          <motion.div
+            initial={{ y: 10, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: 10, opacity: 0 }}
+            transition={{ duration: 0.4, ease: "easeInOut" }}
+            css={STYLES_JUMPER_OVERLAY}
+          />
+        )}
+      </AnimatePresence>
+      
+      <Jumper.Root isOpen={isSettingsJumperVisible} onClose={hideSettingsJumper}>
+        <Jumper.Item css={STYLES_JUMPER_HEADER}>
+          <System.H5 color="textBlack">Settings</System.H5>
+          <button
+            style={{ marginLeft: "auto" }}
+            css={STYLES_JUMPER_DISMISS_BUTTON}
+            onClick={hideSettingsJumper}
+          >
+            <SVG.Dismiss width={20} style={{ display: "block" }} />
+          </button>
+        </Jumper.Item>
+
+        <Jumper.Divider />
+
+        <Jumper.Item css={STYLES_JUMPER_MAIN}>
+          <Sidebar viewer={data} tabs={tabs} />
+          <TabContent viewer={data} onClose={hideSettingsJumper} />
+        </Jumper.Item>
+
+      </Jumper.Root>
+    </>
+  );
+}

--- a/components/core/Settings/Provider.js
+++ b/components/core/Settings/Provider.js
@@ -1,0 +1,36 @@
+import * as React from "react";
+import * as UploadUtilities from "~/common/upload-utilities";
+import * as FileUtilities from "~/common/file-utilities";
+import * as Logging from "~/common/logging";
+
+import { useEventListener } from "~/common/hooks";
+
+const SettingsContext = React.createContext({});
+export const useSettingsContext = () => React.useContext(SettingsContext);
+
+export const Provider = ({ children, viewer }) => {
+  const [isSettingsJumperVisible, { showSettingsJumper, hideSettingsJumper }] = useSettingsJumper();
+
+  useEventListener("open-settings-jumper", showSettingsJumper);
+
+  const providerValue = React.useMemo(
+    () => [
+      { isSettingsJumperVisible },
+      {
+        showSettingsJumper,
+        hideSettingsJumper,
+      },
+    ],
+    [isSettingsJumperVisible]
+  );
+  
+
+  return <SettingsContext.Provider value={providerValue}>{children}</SettingsContext.Provider>;
+};
+
+const useSettingsJumper = () => {
+  const [isSettingsJumperVisible, setSettingsJumperState] = React.useState(false);
+  const showSettingsJumper = () => setSettingsJumperState(true);
+  const hideSettingsJumper = () => setSettingsJumperState(false);
+  return [isSettingsJumperVisible, { showSettingsJumper, hideSettingsJumper }];
+};

--- a/components/core/Settings/index.js
+++ b/components/core/Settings/index.js
@@ -1,0 +1,40 @@
+import * as React from "react";
+import * as Styles from "~/common/styles";
+import * as Events from "~/common/custom-events";
+
+import { ModalPortal } from "../ModalPortal";
+import { Provider } from "~/components/core/Settings/Provider";
+import { SettingsJumper as Jumper } from "~/components/core/Settings/Jumper";
+
+/* -------------------------------------------------------------------------------------------------
+ * Root
+ * -----------------------------------------------------------------------------------------------*/
+const Root = ({ children, viewer }) => {
+  return (
+    <>
+      {children}
+      <ModalPortal>
+        <Jumper data={viewer} />
+      </ModalPortal>
+    </>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * Trigger
+ * -----------------------------------------------------------------------------------------------*/
+
+const Trigger = ({ viewer, css, children, ...props }) => {
+  const showSettingsModal = () => {
+    Events.dispatchCustomEvent({ name: "open-settings-jumper" });
+  };
+  return (
+    <div css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
+      <button css={[Styles.BUTTON_RESET, css]} onClick={showSettingsModal} {...props}>
+        {children}
+      </button>
+    </div>
+  );
+};
+
+export { Provider, Root, Trigger };


### PR DESCRIPTION
Component for new settings jumper, including the modal structure, sidebar and the first profile tab
- settings jumper, open/closing
- sidebar with avatar, username, email and tab buttons
- profile tab with avatar upload, display name and bio change
- replaced the settings link in the drop down menu to open the modal

<img width="648" alt="Screen Shot 2021-11-09 at 1 32 03 PM" src="https://user-images.githubusercontent.com/60402678/141000086-50654161-969b-48de-9a0e-5c4ec34ba329.png">
