### PR TITLE
Improvements and accessibility changes

### DIFF
--- a/common/hooks/a11y.js
+++ b/common/hooks/a11y.js
@@ -1,0 +1,55 @@
+import * as React from "react";
+
+import { first, last } from "lodash";
+import { useEventListener } from "~/common/hooks";
+
+// SOURCE(amine): https://zellwk.com/blog/keyboard-focusable-elements/
+const getFocusableElements = (element = document) =>
+  [
+    ...element.querySelectorAll(
+      'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
+    ),
+  ]
+    // NOTE(amine): remove disabled buttons and elements with aria-hidden attribute
+    .filter(
+      (el) =>
+        !el.hasAttribute("disabled") &&
+        !el.getAttribute("aria-hidden") &&
+        el.getAttribute("tabindex") !== "-1"
+    );
+
+/* NOTE(amine): used to trap focus inside a component. **/
+export const useTrapFocus = ({ ref }) => {
+  const handleFocus = (e) => {
+    if (!ref.current) return;
+    const elements = getFocusableElements(ref.current);
+    const firstElement = first(elements);
+    const lastElement = last(elements);
+
+    const isTabPressed = e.key === "Tab" || e.keyCode === "9";
+    if (!isTabPressed) return;
+
+    if (e.shiftKey) {
+      if (document.activeElement === firstElement) {
+        lastElement.focus();
+        e.preventDefault();
+      }
+    } else {
+      if (document.activeElement === lastElement) {
+        firstElement.focus();
+        e.preventDefault();
+      }
+    }
+  };
+
+  useEventListener({ type: "keydown", handler: handleFocus }, []);
+};
+
+export const useRestoreFocus = ({ isEnabled } = { isEnabled: true }) => {
+  React.useEffect(() => {
+    if (!isEnabled) return;
+
+    const lastActiveElement = typeof document !== "undefined" ? document.activeElement : null;
+    return () => lastActiveElement?.focus?.();
+  }, [isEnabled]);
+};

--- a/common/hooks/index.js
+++ b/common/hooks/index.js
@@ -517,21 +517,3 @@ export const useLocalStorage = (key) => ({
   getItem: () => localStorage?.getItem(key),
   removeItem: () => localStorage?.removeItem(key),
 });
-
-export const useCombinedRefs = (...refs) => {
-  const targetRef = React.useRef();
-
-  React.useEffect(() => {
-    refs.forEach((ref) => {
-      if (!ref) return;
-
-      if (typeof ref === "function") {
-        ref(targetRef.current);
-      } else {
-        ref.current = targetRef.current;
-      }
-    });
-  }, [refs]);
-
-  return targetRef;
-};

--- a/common/hooks/index.js
+++ b/common/hooks/index.js
@@ -517,3 +517,21 @@ export const useLocalStorage = (key) => ({
   getItem: () => localStorage?.getItem(key),
   removeItem: () => localStorage?.removeItem(key),
 });
+
+export const useCombinedRefs = (...refs) => {
+  const targetRef = React.useRef();
+
+  React.useEffect(() => {
+    refs.forEach((ref) => {
+      if (!ref) return;
+
+      if (typeof ref === "function") {
+        ref(targetRef.current);
+      } else {
+        ref.current = targetRef.current;
+      }
+    });
+  }, [refs]);
+
+  return targetRef;
+};

--- a/common/styles.js
+++ b/common/styles.js
@@ -250,12 +250,14 @@ export const OBJECTS_PREVIEW_GRID = (theme) => css`
 `;
 
 export const BUTTON_RESET = css`
+  ${HOVERABLE};
   padding: 0;
   margin: 0;
   background-color: unset;
   border: none;
   cursor: pointer;
-  ${HOVERABLE}
+  outline: 0;
+  border: 0;
 `;
 
 export const COLLECTIONS_PREVIEW_GRID = (theme) => css`

--- a/common/utilities.js
+++ b/common/utilities.js
@@ -1,9 +1,10 @@
-import BCrypt from "bcryptjs";
-
 import * as Strings from "~/common/strings";
 import * as Validations from "~/common/validations";
 import * as Constants from "~/common/constants";
 
+import { jsx } from "@emotion/react";
+
+import BCrypt from "bcryptjs";
 import moment from "moment";
 
 //NOTE(martina): this file is for utility functions that do not involve API calls
@@ -159,7 +160,7 @@ export const getImageUrlIfExists = (file, sizeLimit = null) => {
     }
     return Strings.getURLfromCID(file.cid);
   }
-  let coverImage = file.coverImage;
+  let { coverImage } = file;
   if (coverImage) {
     if (sizeLimit && coverImage.size && coverImage.size > sizeLimit) {
       return;
@@ -173,4 +174,29 @@ export const getImageUrlIfExists = (file, sizeLimit = null) => {
 
 export const getUserDisplayName = (user) => {
   return user.name || `@${user.username}`;
+};
+
+export const mergeEvents =
+  (...handlers) =>
+  (e) => {
+    handlers.forEach((handler) => handler?.call?.(e));
+  };
+
+// NOTE(amine): workaround to support css prop in cloned elements
+// SOURCE(amine): https://github.com/emotion-js/emotion/issues/1404#issuecomment-504527459
+export const cloneElementWithJsx = (element, config, ...children) => {
+  return jsx(
+    element.props["__EMOTION_TYPE_PLEASE_DO_NOT_USE__"]
+      ? element.props["__EMOTION_TYPE_PLEASE_DO_NOT_USE__"]
+      : element.type,
+    {
+      key: element.key !== null ? element.key : undefined,
+      ref: element.ref,
+      ...element.props,
+      ...config,
+      style: { ...element.props?.style, ...config?.style },
+      css: [element.props?.css, config.css],
+    },
+    ...children
+  );
 };

--- a/common/utilities.js
+++ b/common/utilities.js
@@ -182,6 +182,18 @@ export const mergeEvents =
     handlers.forEach((handler) => handler?.call?.(e));
   };
 
+export const mergeRefs = (refs) => {
+  return (value) => {
+    refs.forEach((ref) => {
+      if (typeof ref === "function") {
+        ref(value);
+      } else if (ref != null) {
+        ref.current = value;
+      }
+    });
+  };
+};
+
 // NOTE(amine): workaround to support css prop in cloned elements
 // SOURCE(amine): https://github.com/emotion-js/emotion/issues/1404#issuecomment-504527459
 export const cloneElementWithJsx = (element, config, ...children) => {

--- a/components/core/ApplicationHeader.js
+++ b/components/core/ApplicationHeader.js
@@ -103,7 +103,7 @@ const STYLES_UPLOAD_BUTTON = css`
   height: 24px;
   cursor: pointer;
   pointer-events: auto;
-  transition: all 200ms;
+  transition: background-color 200ms;
 
   :hover {
     background-color: ${Constants.semantic.bgGrayLight4};

--- a/components/core/ApplicationUserControls.js
+++ b/components/core/ApplicationUserControls.js
@@ -4,6 +4,7 @@ import * as Styles from "~/common/styles";
 import * as UserBehaviors from "~/common/user-behaviors";
 import * as Strings from "~/common/strings";
 import * as Utilities from "~/common/utilities";
+import * as System from "~/components/system";
 
 import { PopoverNavigation } from "~/components/system";
 import { css } from "@emotion/react";
@@ -247,13 +248,13 @@ export class ApplicationUserControls extends React.Component {
     let tooltip = <ApplicationUserControlsPopup {...this.props} />;
     return (
       <div css={STYLES_HEADER}>
-        <button
-          css={[Styles.BUTTON_RESET, STYLES_PROFILE_MOBILE]}
+        <System.ButtonPrimitive
+          css={STYLES_PROFILE_MOBILE}
           onClick={() => this.props.onTogglePopup("profile")}
           style={{ position: "relative", cursor: "pointer" }}
         >
           <ProfilePhoto user={this.props.viewer} style={{ borderRadius: "8px" }} size={24} />
-        </button>
+        </System.ButtonPrimitive>
         {this.props.popup === "profile" ? tooltip : null}
       </div>
     );

--- a/components/core/Filter/Filters.js
+++ b/components/core/Filter/Filters.js
@@ -108,14 +108,18 @@ const FilterSection = React.forwardRef(({ title, children, ...props }, ref) => {
         </Tooltip.Root>
       )}
       {isExpanded ? (
-        <motion.ul
-          layoutId={title + "section"}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          css={STYLES_FILTERS_GROUP}
-        >
-          {children}
-        </motion.ul>
+        <RovingTabIndex.Provider axis="vertical">
+          <RovingTabIndex.List>
+            <motion.ul
+              layoutId={title + "section"}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              css={STYLES_FILTERS_GROUP}
+            >
+              {children}
+            </motion.ul>
+          </RovingTabIndex.List>
+        </RovingTabIndex.Provider>
       ) : null}
     </div>
   );
@@ -151,27 +155,23 @@ function Tags({ viewer, data, onAction, ...props }) {
   const [, { hidePopup }] = useFilterContext();
 
   return (
-    <RovingTabIndex.Provider axis="vertical">
-      <RovingTabIndex.List>
-        <FilterSection title="Tags" {...props}>
-          {viewer.slates.map((slate, index) => (
-            <li key={slate.id}>
-              <RovingTabIndex.Item index={index}>
-                <FilterButton
-                  href={`/$/slate/${slate.id}`}
-                  isSelected={slate.id === data?.id}
-                  onAction={onAction}
-                  Icon={slate.isPublic ? SVG.Hash : SVG.SecurityLock}
-                  onClick={hidePopup}
-                >
-                  {slate.slatename}
-                </FilterButton>
-              </RovingTabIndex.Item>
-            </li>
-          ))}
-        </FilterSection>
-      </RovingTabIndex.List>
-    </RovingTabIndex.Provider>
+    <FilterSection title="Tags" {...props}>
+      {viewer.slates.map((slate, index) => (
+        <li key={slate.id}>
+          <RovingTabIndex.Item index={index}>
+            <FilterButton
+              href={`/$/slate/${slate.id}`}
+              isSelected={slate.id === data?.id}
+              onAction={onAction}
+              Icon={slate.isPublic ? SVG.Hash : SVG.SecurityLock}
+              onClick={hidePopup}
+            >
+              {slate.slatename}
+            </FilterButton>
+          </RovingTabIndex.Item>
+        </li>
+      ))}
+    </FilterSection>
   );
 }
 

--- a/components/core/Filter/Filters.js
+++ b/components/core/Filter/Filters.js
@@ -7,6 +7,7 @@ import * as Utilities from "~/common/utilities";
 import * as Tooltip from "~/components/system/components/fragments/Tooltip";
 import * as System from "~/components/system";
 import * as Actions from "~/common/actions";
+import * as RovingTabIndex from "~/components/core/RovingTabIndex";
 
 import ProfilePhoto from "~/components/core/ProfilePhoto";
 
@@ -15,6 +16,7 @@ import { useFilterContext } from "~/components/core/Filter/Provider";
 import { Link } from "~/components/core/Link";
 import { ButtonPrimary, ButtonSecondary } from "~/components/system/components/Buttons";
 import { motion } from "framer-motion";
+import { FocusRing } from "../FocusRing";
 
 /* -------------------------------------------------------------------------------------------------
  *  Shared components between filters
@@ -63,40 +65,40 @@ const STYLES_FILTERS_GROUP = css`
   }
 `;
 
-const FilterButton = ({ children, Icon, image, isSelected, ...props }) => (
-  <li>
-    <Link {...props}>
-      <span as="span" css={[STYLES_FILTER_BUTTON, isSelected && STYLES_FILTER_BUTTON_HIGHLIGHTED]}>
-        {Icon ? <Icon height={16} width={16} style={{ flexShrink: 0 }} /> : null}
-        {image ? image : null}
-        <Typography.P2 as="span" nbrOflines={1} style={{ marginLeft: 6 }}>
-          {children}
-        </Typography.P2>
-      </span>
-    </Link>
-  </li>
-);
+const FilterButton = React.forwardRef(({ children, Icon, image, isSelected, ...props }, ref) => (
+  <Link {...props} ref={ref}>
+    <span as="span" css={[STYLES_FILTER_BUTTON, isSelected && STYLES_FILTER_BUTTON_HIGHLIGHTED]}>
+      {Icon ? <Icon height={16} width={16} style={{ flexShrink: 0 }} /> : null}
+      {image ? image : null}
+      <Typography.P2 as="span" nbrOflines={1} style={{ marginLeft: 6 }}>
+        {children}
+      </Typography.P2>
+    </span>
+  </Link>
+));
 
-const FilterSection = ({ title, children, ...props }) => {
+const FilterSection = React.forwardRef(({ title, children, ...props }, ref) => {
   const [isExpanded, setExpanded] = React.useState(true);
   const toggleExpandState = () => setExpanded((prev) => !prev);
 
   const titleButtonId = `sidebar-${title}-button`;
   return (
-    <div {...props}>
+    <div {...props} ref={ref}>
       {title && (
         <Tooltip.Root vertical="above" horizontal="right">
           <Tooltip.Trigger aria-describedby={titleButtonId} aria-expanded={isExpanded}>
-            <Typography.H6
-              as={motion.button}
-              layoutId={title + "title"}
-              css={STYLES_FILTER_TITLE_BUTTON}
-              style={{ paddingLeft: 8, marginBottom: 4 }}
-              onClick={toggleExpandState}
-              color="textGray"
-            >
-              {title}
-            </Typography.H6>
+            <FocusRing>
+              <Typography.H6
+                as={motion.button}
+                layoutId={title + "title"}
+                css={STYLES_FILTER_TITLE_BUTTON}
+                style={{ paddingLeft: 8, marginBottom: 4 }}
+                onClick={toggleExpandState}
+                color="textGray"
+              >
+                {title}
+              </Typography.H6>
+            </FocusRing>
           </Tooltip.Trigger>
           <Tooltip.Content css={Styles.HORIZONTAL_CONTAINER_CENTERED} style={{ marginTop: -4.5 }}>
             <System.H6 id={titleButtonId} as="p" color="textGrayDark">
@@ -117,7 +119,7 @@ const FilterSection = ({ title, children, ...props }) => {
       ) : null}
     </div>
   );
-};
+});
 
 /* -------------------------------------------------------------------------------------------------
  *  InitialFilters
@@ -149,20 +151,27 @@ function Tags({ viewer, data, onAction, ...props }) {
   const [, { hidePopup }] = useFilterContext();
 
   return (
-    <FilterSection title="Tags" {...props}>
-      {viewer.slates.map((slate) => (
-        <FilterButton
-          key={slate.id}
-          href={`/$/slate/${slate.id}`}
-          isSelected={slate.id === data?.id}
-          onAction={onAction}
-          Icon={slate.isPublic ? SVG.Hash : SVG.SecurityLock}
-          onClick={hidePopup}
-        >
-          {slate.slatename}
-        </FilterButton>
-      ))}
-    </FilterSection>
+    <RovingTabIndex.Provider axis="vertical">
+      <RovingTabIndex.List>
+        <FilterSection title="Tags" {...props}>
+          {viewer.slates.map((slate, index) => (
+            <li key={slate.id}>
+              <RovingTabIndex.Item index={index}>
+                <FilterButton
+                  href={`/$/slate/${slate.id}`}
+                  isSelected={slate.id === data?.id}
+                  onAction={onAction}
+                  Icon={slate.isPublic ? SVG.Hash : SVG.SecurityLock}
+                  onClick={hidePopup}
+                >
+                  {slate.slatename}
+                </FilterButton>
+              </RovingTabIndex.Item>
+            </li>
+          ))}
+        </FilterSection>
+      </RovingTabIndex.List>
+    </RovingTabIndex.Provider>
   );
 }
 
@@ -170,21 +179,28 @@ function Following({ viewer, onAction, ...props }) {
   const [, { hidePopup }] = useFilterContext();
 
   return (
-    <FilterSection title="Following" {...props}>
-      {viewer.following.map((user) => (
-        <FilterButton
-          key={user.id}
-          href={`/${user.username}`}
-          isSelected={false}
-          onAction={onAction}
-          // Icon={SVG.ProfileUser}
-          image={<ProfilePhoto user={user} style={{ borderRadius: "8px" }} size={20} />}
-          onClick={hidePopup}
-        >
-          {user.username}
-        </FilterButton>
-      ))}
-    </FilterSection>
+    <RovingTabIndex.Provider axis="vertical">
+      <RovingTabIndex.List>
+        <FilterSection title="Following" {...props}>
+          {viewer.following.map((user, index) => (
+            <li key={user.id}>
+              <RovingTabIndex.Item index={index}>
+                <FilterButton
+                  href={`/${user.username}`}
+                  isSelected={false}
+                  onAction={onAction}
+                  // Icon={SVG.ProfileUser}
+                  image={<ProfilePhoto user={user} style={{ borderRadius: "8px" }} size={20} />}
+                  onClick={hidePopup}
+                >
+                  {user.username}
+                </FilterButton>
+              </RovingTabIndex.Item>
+            </li>
+          ))}
+        </FilterSection>
+      </RovingTabIndex.List>
+    </RovingTabIndex.Provider>
   );
 }
 
@@ -281,20 +297,27 @@ function ProfileTags({ data, page, onAction, ...props }) {
   }
 
   return (
-    <FilterSection {...props}>
-      {user?.slates?.map((slate) => (
-        <FilterButton
-          key={slate.id}
-          href={`/$/slate/${slate.id}`}
-          isSelected={slate.id === data?.id}
-          onAction={onAction}
-          Icon={slate.isPublic ? SVG.Hash : SVG.SecurityLock}
-          onClick={hidePopup}
-        >
-          {slate.slatename}
-        </FilterButton>
-      ))}
-    </FilterSection>
+    <RovingTabIndex.Provider axis="vertical">
+      <RovingTabIndex.List>
+        <FilterSection {...props}>
+          {user?.slates?.map((slate, index) => (
+            <li key={slate.id}>
+              <RovingTabIndex.Item index={index}>
+                <FilterButton
+                  href={`/$/slate/${slate.id}`}
+                  isSelected={slate.id === data?.id}
+                  onAction={onAction}
+                  Icon={slate.isPublic ? SVG.Hash : SVG.SecurityLock}
+                  onClick={hidePopup}
+                >
+                  {slate.slatename}
+                </FilterButton>
+              </RovingTabIndex.Item>
+            </li>
+          ))}
+        </FilterSection>
+      </RovingTabIndex.List>
+    </RovingTabIndex.Provider>
   );
 }
 

--- a/components/core/Filter/Filters.js
+++ b/components/core/Filter/Filters.js
@@ -77,7 +77,7 @@ const FilterButton = ({ children, Icon, image, isSelected, ...props }) => (
   </li>
 );
 
-const FilterSection = ({ title, tooltipContent, children, ...props }) => {
+const FilterSection = ({ title, children, ...props }) => {
   const [isExpanded, setExpanded] = React.useState(true);
   const toggleExpandState = () => setExpanded((prev) => !prev);
 
@@ -100,7 +100,7 @@ const FilterSection = ({ title, tooltipContent, children, ...props }) => {
           </Tooltip.Trigger>
           <Tooltip.Content css={Styles.HORIZONTAL_CONTAINER_CENTERED} style={{ marginTop: -4.5 }}>
             <System.H6 id={titleButtonId} as="p" color="textGrayDark">
-              {tooltipContent}
+              Click to show/hide the filter section
             </System.H6>
           </Tooltip.Content>
         </Tooltip.Root>
@@ -149,7 +149,7 @@ function Tags({ viewer, data, onAction, ...props }) {
   const [, { hidePopup }] = useFilterContext();
 
   return (
-    <FilterSection title="Tags" tooltipContent="Click to show/hide the tags section" {...props}>
+    <FilterSection title="Tags" {...props}>
       {viewer.slates.map((slate) => (
         <FilterButton
           key={slate.id}

--- a/components/core/Filter/Popup.js
+++ b/components/core/Filter/Popup.js
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as SVG from "~/common/svg";
 import * as Styles from "~/common/styles";
 import * as Filters from "~/components/core/Filter/Filters";
+import * as System from "~/components/system";
 
 import { useFilterContext } from "~/components/core/Filter/Provider";
 import { motion } from "framer-motion";
@@ -23,16 +24,19 @@ export function PopupTrigger({ children, isMobile, ...props }) {
   if (sidebarState.isVisible && !isMobile) return null;
 
   return (
-    <button
+    <System.ButtonPrimitive
       onClick={togglePopup}
-      css={[Styles.BUTTON_RESET, Styles.HORIZONTAL_CONTAINER_CENTERED]}
+      css={Styles.HORIZONTAL_CONTAINER_CENTERED}
       {...props}
     >
       {children}
-      <motion.div initial={null} animate={{ rotateX: popupState.isVisible ? 0 : 180 }}>
+      <motion.div
+        initial={{ rotateX: popupState.isVisible ? 0 : 180 }}
+        animate={{ rotateX: popupState.isVisible ? 0 : 180 }}
+      >
         <SVG.ChevronUp style={{ display: "block" }} />
       </motion.div>
-    </button>
+    </System.ButtonPrimitive>
   );
 }
 

--- a/components/core/Filter/Provider.js
+++ b/components/core/Filter/Provider.js
@@ -1,4 +1,3 @@
-import { has } from "lodash";
 import * as React from "react";
 import * as Actions from "~/common/actions";
 import * as Events from "~/common/custom-events";

--- a/components/core/Filter/Sidebar.js
+++ b/components/core/Filter/Sidebar.js
@@ -3,9 +3,12 @@ import * as SVG from "~/common/svg";
 import * as Styles from "~/common/styles";
 import * as Filters from "~/components/core/Filter/Filters";
 import * as Constants from "~/common/constants";
+import * as System from "~/components/system";
+import * as Tooltip from "~/components/system/components/fragments/Tooltip";
 
 import { useFilterContext } from "~/components/core/Filter/Provider";
 import { css } from "@emotion/react";
+import { useEventListener } from "~/common/hooks";
 
 /* -------------------------------------------------------------------------------------------------
  * Sidebar trigger
@@ -22,21 +25,46 @@ const STYLES_SIDEBAR_TRIGGER = (theme) => css`
   }
 `;
 
-export function SidebarTrigger({ css }) {
+export const SidebarTrigger = React.forwardRef(({ css, isMobile, ...props }, ref) => {
   const [{ sidebarState }, { toggleSidebar }] = useFilterContext();
+
+  const handleKeyDown = (e) => {
+    if (e.key === "\\" || e.code === "Backslash") toggleSidebar();
+  };
+  useEventListener({ type: "keydown", handler: handleKeyDown, enabled: !isMobile });
+
   return (
-    <button
-      onClick={toggleSidebar}
-      css={[STYLES_SIDEBAR_TRIGGER, css]}
-      style={{
-        backgroundColor: sidebarState.isVisible ? Constants.semantic.bgGrayLight : "unset",
-        color: sidebarState.isVisible ? Constants.semantic.textBlack : Constants.semantic.textGray,
-      }}
-    >
-      <SVG.Sidebar style={{ display: "block" }} />
-    </button>
+    <Tooltip.Root vertical="below" horizontal="right">
+      <Tooltip.Trigger aria-describedby="filter-sidebar-trigger-tooltip">
+        <button
+          onClick={toggleSidebar}
+          css={[STYLES_SIDEBAR_TRIGGER, css]}
+          style={{
+            backgroundColor: sidebarState.isVisible ? Constants.semantic.bgGrayLight : "unset",
+            color: sidebarState.isVisible
+              ? Constants.semantic.textBlack
+              : Constants.semantic.textGray,
+          }}
+          ref={ref}
+          {...props}
+        >
+          <SVG.Sidebar style={{ display: "block" }} />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content
+        style={{ marginTop: 4.5, marginLeft: -8 }}
+        css={Styles.HORIZONTAL_CONTAINER_CENTERED}
+      >
+        <System.H6 id="filter-sidebar-trigger-tooltip" as="p" color="textGrayDark">
+          Click to show/hide the sidebar
+        </System.H6>
+        <System.H6 as="p" color="textGray" style={{ marginLeft: 16 }}>
+          \
+        </System.H6>
+      </Tooltip.Content>
+    </Tooltip.Root>
   );
-}
+});
 
 /* -------------------------------------------------------------------------------------------------
  *  Sidebar
@@ -47,7 +75,7 @@ const STYLES_SIDEBAR_FILTER_WRAPPER = (theme) => css`
   top: ${theme.sizes.header + theme.sizes.filterNavbar}px;
   width: 300px;
   height: calc(100vh - ${theme.sizes.header + theme.sizes.filterNavbar}px);
-  overflow-y: auto;
+  overflow-y: overlay;
   padding: 20px 24px calc(16px + ${theme.sizes.intercomWidget}px + ${theme.sizes.filterNavbar}px);
   background-color: ${theme.semantic.bgLight};
 
@@ -96,7 +124,6 @@ export function Sidebar({ viewer, onAction, data, page, isMobile, isProfilePage 
           style={{ marginTop: 12 }}
         />
         <Filters.Following
-          page={page}
           onAction={onAction}
           data={data}
           viewer={viewer}

--- a/components/core/Filter/Sidebar.js
+++ b/components/core/Filter/Sidebar.js
@@ -75,7 +75,8 @@ const STYLES_SIDEBAR_FILTER_WRAPPER = (theme) => css`
   top: ${theme.sizes.header + theme.sizes.filterNavbar}px;
   width: 300px;
   height: calc(100vh - ${theme.sizes.header + theme.sizes.filterNavbar}px);
-  overflow-y: overlay;
+  overflow: auto;
+  overflow: overlay;
   padding: 20px 24px calc(16px + ${theme.sizes.intercomWidget}px + ${theme.sizes.filterNavbar}px);
   background-color: ${theme.semantic.bgLight};
 

--- a/components/core/Filter/Sidebar.js
+++ b/components/core/Filter/Sidebar.js
@@ -15,7 +15,6 @@ import { useEventListener } from "~/common/hooks";
  * -----------------------------------------------------------------------------------------------*/
 
 const STYLES_SIDEBAR_TRIGGER = (theme) => css`
-  ${Styles.BUTTON_RESET};
   color: ${theme.semantic.textBlack};
   border-radius: 6px;
   padding: 2px;
@@ -29,6 +28,10 @@ export const SidebarTrigger = React.forwardRef(({ css, isMobile, ...props }, ref
   const [{ sidebarState }, { toggleSidebar }] = useFilterContext();
 
   const handleKeyDown = (e) => {
+    const targetTagName = e.target.tagName;
+    if (targetTagName === "INPUT" || targetTagName === "TEXTAREA" || targetTagName === "SELECT")
+      return;
+
     if (e.key === "\\" || e.code === "Backslash") toggleSidebar();
   };
   useEventListener({ type: "keydown", handler: handleKeyDown, enabled: !isMobile });
@@ -36,7 +39,7 @@ export const SidebarTrigger = React.forwardRef(({ css, isMobile, ...props }, ref
   return (
     <Tooltip.Root vertical="below" horizontal="right">
       <Tooltip.Trigger aria-describedby="filter-sidebar-trigger-tooltip">
-        <button
+        <System.ButtonPrimitive
           onClick={toggleSidebar}
           css={[STYLES_SIDEBAR_TRIGGER, css]}
           style={{
@@ -49,7 +52,7 @@ export const SidebarTrigger = React.forwardRef(({ css, isMobile, ...props }, ref
           {...props}
         >
           <SVG.Sidebar style={{ display: "block" }} />
-        </button>
+        </System.ButtonPrimitive>
       </Tooltip.Trigger>
       <Tooltip.Content
         style={{ marginTop: 4.5, marginLeft: -8 }}

--- a/components/core/Filter/index.js
+++ b/components/core/Filter/index.js
@@ -10,24 +10,42 @@ import { Provider } from "~/components/core/Filter/Provider";
 import { Sidebar, SidebarTrigger } from "~/components/core/Filter/Sidebar";
 import { Popup, PopupTrigger } from "~/components/core/Filter/Popup";
 import { useSearchStore } from "~/components/core/Search/store";
+import { LoaderSpinner } from "~/components/system/components/Loaders";
 
 /* -------------------------------------------------------------------------------------------------
  *  Title
  * -----------------------------------------------------------------------------------------------*/
 
 function Title({ page, data }) {
-  const { query, isSearching } = useSearchStore();
+  const { query, results, isFetchingResults, isSearching } = useSearchStore();
   let title = React.useMemo(() => {
-    if (isSearching) return `Searching for ${query}`;
+    if (isFetchingResults)
+      return (
+        <div css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
+          <LoaderSpinner style={{ height: 16, width: 16 }} />
+          <System.H5
+            title={title}
+            style={{ maxWidth: 400, marginLeft: 8 }}
+            as="p"
+            nbrOflines={1}
+            color="textBlack"
+          >
+            Searching: {query}
+          </System.H5>
+        </div>
+      );
+    if (results && query) return `Showing results for: "${query}"`;
     if (page.id === "NAV_DATA") return "My library";
     if (page.id === "NAV_SLATE" && data?.slatename) return "# " + data?.slatename;
     if (page.id === "NAV_PROFILE") return "@ " + data.username;
-  }, [page, data, query, isSearching]);
+  }, [page, data, isFetchingResults, isSearching]);
 
-  return (
+  return typeof title === "string" ? (
     <System.H5 title={title} style={{ maxWidth: 400 }} as="p" nbrOflines={1} color="textBlack">
       {title}
     </System.H5>
+  ) : (
+    title
   );
 }
 

--- a/components/core/Filter/index.js
+++ b/components/core/Filter/index.js
@@ -163,7 +163,7 @@ export default function Filter({
           {isProfilePage && !isMobile ? null : (
             <div css={Styles.CONTAINER_CENTERED}>
               <div css={Styles.MOBILE_HIDDEN}>
-                <SidebarTrigger />
+                <SidebarTrigger isMobile={isMobile} />
               </div>
               <PopupTrigger isMobile={isMobile} style={{ marginLeft: 2 }}>
                 <span css={Styles.MOBILE_ONLY} style={{ marginRight: 8 }}>

--- a/components/core/Filter/index.js
+++ b/components/core/Filter/index.js
@@ -145,7 +145,7 @@ export default function Filter({
 
   if (disabled) {
     return showSearchResult ? (
-      <Search.Content viewer={viewer} page={page} onAction={onAction} />
+      <Search.Content viewer={viewer} page={page} onAction={onAction} isMobile={isMobile} />
     ) : (
       children
     );
@@ -208,7 +208,7 @@ export default function Filter({
         />
         <div style={{ flexGrow: 1 }}>
           {showSearchResult ? (
-            <Search.Content viewer={viewer} page={page} onAction={onAction} />
+            <Search.Content viewer={viewer} page={page} onAction={onAction} isMobile={isMobile} />
           ) : (
             children
           )}

--- a/components/core/FocusRing.js
+++ b/components/core/FocusRing.js
@@ -1,0 +1,56 @@
+import * as React from "react";
+
+import { css } from "@emotion/react";
+import { mergeEvents, cloneElementWithJsx } from "~/common/utilities";
+import { useCombinedRefs } from "~/common/hooks";
+
+const hasElementFocus = (el) => el.matches(":focus");
+const hasElementFocusWithin = (el) => el.matches(":focus-within");
+
+let isFocusViaKeyboard = false;
+if (typeof window !== "undefined") {
+  window?.addEventListener("mousedown", () => (isFocusViaKeyboard = false));
+  window?.addEventListener("keydown", () => (isFocusViaKeyboard = true));
+}
+
+const useFocusRing = ({ within, ref }) => {
+  const [isFocused, setFocus] = React.useState(false);
+
+  const enableFocusRing = () => {
+    if (isFocusViaKeyboard && ref.current) {
+      setFocus(within ? hasElementFocusWithin(ref.current) : hasElementFocus(ref.current));
+    }
+  };
+  const disableFocusRing = () => setFocus(false);
+
+  return [isFocused, { enableFocusRing, disableFocusRing }];
+};
+
+const STYLES_FOCUS_RING_DEFAULT = (theme) => css`
+  outline: 2px solid ${theme.system.blue};
+`;
+
+export const FocusRing = React.forwardRef(
+  (
+    { children, within, style, css = STYLES_FOCUS_RING_DEFAULT, disabled, ...props },
+    forwardedRef
+  ) => {
+    const innerRef = React.useRef();
+    const ref = useCombinedRefs(innerRef, forwardedRef, children.ref);
+
+    const [isFocused, { enableFocusRing, disableFocusRing }] = useFocusRing({ within, ref });
+
+    React.useLayoutEffect(() => {
+      enableFocusRing();
+    }, []);
+
+    return cloneElementWithJsx(React.Children.only(children), {
+      ...props,
+      onFocus: mergeEvents(enableFocusRing, children.onFocus),
+      onBlur: mergeEvents(disableFocusRing, children.onBlur),
+      css: isFocused && !disabled ? css : null,
+      style: isFocused && !disabled ? style : null,
+      ref,
+    });
+  }
+);

--- a/components/core/FocusRing.js
+++ b/components/core/FocusRing.js
@@ -1,8 +1,7 @@
 import * as React from "react";
 
 import { css } from "@emotion/react";
-import { mergeEvents, cloneElementWithJsx } from "~/common/utilities";
-import { useCombinedRefs } from "~/common/hooks";
+import { mergeEvents, mergeRefs, cloneElementWithJsx } from "~/common/utilities";
 
 const hasElementFocus = (el) => el.matches(":focus");
 const hasElementFocusWithin = (el) => el.matches(":focus-within");
@@ -35,8 +34,7 @@ export const FocusRing = React.forwardRef(
     { children, within, style, css = STYLES_FOCUS_RING_DEFAULT, disabled, ...props },
     forwardedRef
   ) => {
-    const innerRef = React.useRef();
-    const ref = useCombinedRefs(innerRef, forwardedRef, children.ref);
+    const ref = React.useRef();
 
     const [isFocused, { enableFocusRing, disableFocusRing }] = useFocusRing({ within, ref });
 
@@ -50,7 +48,7 @@ export const FocusRing = React.forwardRef(
       onBlur: mergeEvents(disableFocusRing, children.onBlur),
       css: isFocused && !disabled ? css : null,
       style: isFocused && !disabled ? style : null,
-      ref,
+      ref: mergeRefs([ref, forwardedRef, children.ref]),
     });
   }
 );

--- a/components/core/Link.js
+++ b/components/core/Link.js
@@ -63,7 +63,21 @@ class LinkPrimitive extends React.Component {
   };
 
   render() {
-    const { style, innerRef, css, target, href, title, children, ...props } = this.props;
+    const {
+      redirect,
+      callback,
+      params,
+      onAction,
+      onUpdate,
+      style,
+      css,
+      innerRef,
+      target,
+      href,
+      title,
+      children,
+      ...props
+    } = this.props;
     return (
       <span onClick={this._handleClick}>
         <a

--- a/components/core/Link.js
+++ b/components/core/Link.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as Strings from "~/common/strings";
 import * as Logging from "~/common/logging";
 
-export class Link extends React.Component {
+class LinkPrimitive extends React.Component {
   state = {
     href: this.props.href
       ? this.props.href
@@ -63,6 +63,7 @@ export class Link extends React.Component {
   };
 
   render() {
+    const { style, innerRef, css, target, href, title, children, ...props } = this.props;
     return (
       <span onClick={this._handleClick}>
         <a
@@ -70,17 +71,20 @@ export class Link extends React.Component {
             textDecoration: "none",
             color: "inherit",
             cursor: "pointer",
-            ...this.props.style,
+            ...style,
           }}
-          css={this.props.css}
-          target={this.props.target}
-          href={this.state.href}
-          aria-label={this.props["aria-label"]}
-          title={this.props.title}
+          ref={innerRef}
+          css={css}
+          target={target}
+          href={href}
+          title={title}
+          {...props}
         >
-          {this.props.children}
+          {children}
         </a>
       </span>
     );
   }
 }
+
+export const Link = React.forwardRef((props, ref) => <LinkPrimitive {...props} innerRef={ref} />);

--- a/components/core/ObjectPreview/ImageObjectPreview.js
+++ b/components/core/ObjectPreview/ImageObjectPreview.js
@@ -91,7 +91,7 @@ export default function ImageObjectPreview({
           <img
             css={STYLES_IMAGE}
             src={imageUrl}
-            alt={`${file.name} preview`}
+            alt={`${file?.name || file.filename} preview`}
             onLoad={handleOnLoaded}
           />
         )}

--- a/components/core/Onboarding/Upload.js
+++ b/components/core/Onboarding/Upload.js
@@ -188,7 +188,7 @@ function ExtensionOnboarding({ isMobile }) {
     <ModalPortal>
       <MobileJumper.AnimatePresence>
         {isMobile ? (
-          <MobileJumper.Root withDismissButton={false}>
+          <MobileJumper.Root>
             <MobileJumper.Header>{header}</MobileJumper.Header>
             <MobileJumper.Content style={{ padding: 0, marginTop: 28 }}>
               {body}
@@ -198,7 +198,7 @@ function ExtensionOnboarding({ isMobile }) {
         ) : null}
       </MobileJumper.AnimatePresence>
       {!isMobile ? (
-        <Jumper.Root withDismissButton={false}>
+        <Jumper.Root>
           <Jumper.Header>{header}</Jumper.Header>
           <Jumper.Item style={{ flexGrow: 1, paddingLeft: 0, paddingRight: 0, paddingBottom: 0 }}>
             {body}

--- a/components/core/RovingTabIndex.js
+++ b/components/core/RovingTabIndex.js
@@ -66,13 +66,14 @@ const useRovingHandler = ({ ref }) => {
   const [{ axis }, { setIndexToNextElement, setIndexPreviousElement }] = useRovingIndexContext();
 
   const keydownHandler = (e) => {
+    const preventDefaults = () => (e.preventDefault(), e.stopPropagation());
     if (axis === "vertical") {
-      if (e.key === "ArrowUp") e.preventDefault(), setIndexPreviousElement();
-      if (e.key === "ArrowDown") e.preventDefault(), setIndexToNextElement();
+      if (e.key === "ArrowUp") preventDefaults(), setIndexPreviousElement();
+      if (e.key === "ArrowDown") preventDefaults(), e.stopPropagation(), setIndexToNextElement();
       return;
     }
-    if (e.key === "ArrowLeft") e.preventDefault(), setIndexPreviousElement();
-    if (e.key === "ArrowRight") e.preventDefault(), setIndexToNextElement();
+    if (e.key === "ArrowLeft") preventDefaults(), setIndexPreviousElement();
+    if (e.key === "ArrowRight") preventDefaults(), setIndexToNextElement();
   };
   useEventListener({
     type: "keydown",

--- a/components/core/RovingTabIndex.js
+++ b/components/core/RovingTabIndex.js
@@ -1,0 +1,102 @@
+import * as React from "react";
+
+import { mergeRefs } from "~/common/utilities";
+import { useEventListener, useMounted } from "~/common/hooks";
+
+/* -------------------------------------------------------------------------------------------------
+ * RovingTabIndex Provider
+ * -----------------------------------------------------------------------------------------------*/
+
+const rovingIndexContext = React.createContext({});
+const useRovingIndexContext = () => React.useContext(rovingIndexContext);
+
+export function Provider({ axis, children }) {
+  const focusedElementsRefs = React.useRef({});
+  const initialIndex = 0;
+  const [focusedIndex, setFocusedIndex] = React.useState(initialIndex);
+
+  const registerItem = ({ index, ref }) => (focusedElementsRefs.current[index] = ref);
+  const cleanupItem = (index) => delete focusedElementsRefs.current[index];
+
+  const setIndexToNextElement = () => {
+    const nextIndex = focusedIndex + 1;
+    const elementsExists = focusedElementsRefs.current[nextIndex];
+    setFocusedIndex(elementsExists ? nextIndex : initialIndex);
+  };
+  const setIndexPreviousElement = () => {
+    const prevIndex = focusedIndex - 1;
+    if (prevIndex >= initialIndex) {
+      setFocusedIndex(prevIndex);
+      return;
+    }
+    const lastIndex = Math.max(...Object.keys(focusedElementsRefs.current));
+    setFocusedIndex(lastIndex);
+  };
+
+  useMounted(() => {
+    const focusedElementRef = focusedElementsRefs.current[focusedIndex];
+    focusedElementRef?.current?.focus();
+  }, [focusedIndex]);
+
+  const contextValue = React.useMemo(
+    () => [
+      { focusedIndex, axis },
+      { registerItem, cleanupItem, setIndexToNextElement, setIndexPreviousElement },
+    ],
+    [focusedIndex]
+  );
+
+  return <rovingIndexContext.Provider value={contextValue}>{children}</rovingIndexContext.Provider>;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * RovingTabIndex List
+ * -----------------------------------------------------------------------------------------------*/
+const useRovingHandler = ({ ref }) => {
+  const [{ axis }, { setIndexToNextElement, setIndexPreviousElement }] = useRovingIndexContext();
+
+  const keydownHandler = (e) => {
+    if (axis === "vertical") {
+      if (e.key === "ArrowUp") e.preventDefault(), setIndexPreviousElement();
+      if (e.key === "ArrowDown") e.preventDefault(), setIndexToNextElement();
+      return;
+    }
+    if (e.key === "ArrowLeft") e.preventDefault(), setIndexPreviousElement();
+    if (e.key === "ArrowRight") e.preventDefault(), setIndexToNextElement();
+  };
+  useEventListener({
+    type: "keydown",
+    handler: keydownHandler,
+    ref,
+  });
+};
+
+export const List = React.forwardRef(({ children }, forwardedRef) => {
+  const ref = React.useRef();
+  useRovingHandler({ ref });
+
+  return React.cloneElement(React.Children.only(children), {
+    ref: mergeRefs([ref, children.ref, forwardedRef]),
+  });
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * RovingTabIndex Item
+ * -----------------------------------------------------------------------------------------------*/
+
+export const Item = React.forwardRef(({ children, index, ...props }, forwardedRef) => {
+  const [{ focusedIndex }, { registerItem, cleanupItem }] = useRovingIndexContext();
+  const ref = React.useRef();
+
+  React.useLayoutEffect(() => {
+    if (!ref.current) return;
+    registerItem({ index, ref });
+    return () => cleanupItem(index);
+  }, [index]);
+
+  return React.cloneElement(React.Children.only(children), {
+    ...props,
+    tabIndex: focusedIndex === index ? 0 : -1,
+    ref: mergeRefs([ref, forwardedRef, children.ref]),
+  });
+});

--- a/components/core/Search/index.js
+++ b/components/core/Search/index.js
@@ -1,11 +1,11 @@
 import * as React from "react";
 import * as SVG from "~/common/svg";
 import * as Styles from "~/common/styles";
+import * as System from "~/components/system";
 
 import { css } from "@emotion/react";
 import { Input as InputPrimitive } from "~/components/system/components/Input";
 import { useSearchStore } from "~/components/core/Search/store";
-import { LoaderSpinner } from "~/components/system/components/Loaders";
 import { FileTypeGroup } from "~/components/core/FileTypeIcon";
 import { Link } from "~/components/core/Link";
 
@@ -22,10 +22,10 @@ const STYLES_SEARCH_COMPONENT = (theme) => css`
   background-color: transparent;
   box-shadow: none;
   height: 100%;
+  border-radius: 0px;
   input {
     height: 100%;
     padding: 0px 4px;
-    border-radius: 0px;
   }
   &::placeholder {
     color: ${theme.semantic.textGray};
@@ -59,7 +59,7 @@ const useDebouncedSearch = ({ handleSearch }) => {
 };
 
 function Input({ viewer, data, page, onAction }) {
-  const { search, query, isFetchingResults, setQuery } = useSearchStore();
+  const { search, query, setQuery } = useSearchStore();
 
   const handleSearch = async (query) => {
     // NOTE(amine): update params with search query
@@ -93,7 +93,6 @@ function Input({ viewer, data, page, onAction }) {
 
     //NOTE(amine): searching on another user's profile
     if (page.id === "NAV_PROFILE" && data?.id !== viewer?.id) {
-      console.log(data?.id, page.id, page.id === "NAV_PROFILE", data?.id !== viewer?.id);
       search({
         types: ["SLATE", "FILE"],
         userId: data.id,
@@ -128,7 +127,18 @@ function Input({ viewer, data, page, onAction }) {
   useDebouncedSearch({ handleSearch });
 
   return (
-    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        /**
+         * NOTE(amine): Since this input takes 100% of the parent's height, the top part of the focusRing will be hidden.
+         * To fix this we add a 2px margin-top. (2px is the width of the focusRing)
+         *  */
+        marginTop: "2px",
+        height: "calc(100% - 2px)",
+      }}
+    >
       <InputPrimitive
         full
         containerStyle={{ height: "100%" }}
@@ -139,12 +149,6 @@ function Input({ viewer, data, page, onAction }) {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
-
-      {isFetchingResults && (
-        <div style={{ position: "absolute", right: 0, top: 0 }}>
-          <LoaderSpinner style={{ position: "block", height: 16, width: 16 }} />
-        </div>
-      )}
     </div>
   );
 }
@@ -155,7 +159,6 @@ function Input({ viewer, data, page, onAction }) {
 
 const STYLES_DISMISS_BUTTON = (theme) => css`
   display: block;
-  ${Styles.BUTTON_RESET};
   color: ${theme.semantic.textGray};
 `;
 
@@ -163,9 +166,9 @@ function Dismiss({ css, ...props }) {
   const { clearSearch } = useSearchStore();
 
   return (
-    <button onClick={clearSearch} css={[STYLES_DISMISS_BUTTON, css]} {...props}>
+    <System.ButtonPrimitive onClick={clearSearch} css={[STYLES_DISMISS_BUTTON, css]} {...props}>
       <SVG.Dismiss style={{ display: "block" }} height={16} width={16} />
-    </button>
+    </System.ButtonPrimitive>
   );
 }
 

--- a/components/core/Search/index.js
+++ b/components/core/Search/index.js
@@ -48,14 +48,14 @@ const useSearchViaParams = ({ params, handleSearch }) => {
   }, [params.s]);
 };
 
-const useDebouncedSearch = ({ handleSearch }) => {
-  const { query } = useSearchStore();
-
+const useDebouncedOnChange = ({ setQuery, handleSearch }) => {
   const timeRef = React.useRef();
-  React.useEffect(() => {
-    timeRef.current = setTimeout(() => handleSearch(query), 300);
-    return () => clearTimeout(timeRef.current);
-  }, [query]);
+  const handleChange = (e) => {
+    clearTimeout(timeRef.current);
+    const { value } = e.target;
+    timeRef.current = setTimeout(() => (setQuery(value), handleSearch(value)), 300);
+  };
+  return handleChange;
 };
 
 function Input({ viewer, data, page, onAction }) {
@@ -124,7 +124,7 @@ function Input({ viewer, data, page, onAction }) {
 
   useSearchViaParams({ params: page.params, onAction, handleSearch });
 
-  useDebouncedSearch({ handleSearch });
+  const handleChange = useDebouncedOnChange({ setQuery, handleSearch });
 
   return (
     <div
@@ -146,8 +146,7 @@ function Input({ viewer, data, page, onAction }) {
         name="search"
         placeholder={`Search ${!viewer ? "slate.host" : ""}`}
         onSubmit={() => handleSearch(query)}
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
+        onChange={handleChange}
       />
     </div>
   );

--- a/components/core/Search/index.js
+++ b/components/core/Search/index.js
@@ -176,7 +176,7 @@ function Dismiss({ css, ...props }) {
  *  Content
  * -----------------------------------------------------------------------------------------------*/
 
-function Content({ onAction, viewer, page }) {
+function Content({ onAction, viewer, page, isMobile }) {
   const { results } = useSearchStore();
   const { files, slates } = results;
 
@@ -199,6 +199,7 @@ function Content({ onAction, viewer, page }) {
         items={files}
         onAction={onAction}
         viewer={viewer}
+        isMobile={isMobile}
         page={page}
         view="grid"
       />

--- a/components/core/Upload/Jumper.js
+++ b/components/core/Upload/Jumper.js
@@ -13,9 +13,9 @@ import { css } from "@emotion/react";
 import { useUploadContext } from "~/components/core/Upload/Provider";
 import { useUploadStore } from "~/components/core/Upload/store";
 import { useUploadOnboardingContext } from "~/components/core/Onboarding/Upload";
+import { useCheckIfExtensionIsInstalled, useLocalStorage } from "~/common/hooks";
 
 import DownloadExtensionButton from "~/components/core/Extension/DownloadExtensionButton";
-import { useCheckIfExtensionIsInstalled, useLocalStorage } from "~/common/hooks";
 
 const STYLES_EXTENSION_BAR = (theme) => css`
   ${Styles.HORIZONTAL_CONTAINER_CENTERED};
@@ -43,13 +43,12 @@ function ExtensionBar() {
       <System.P2 color="textBlack">Save from anywhere on the Web</System.P2>
       <div css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
         <DownloadExtensionButton style={{ minHeight: 24, borderRadius: "8px" }} />
-        <button
-          css={Styles.BUTTON_RESET}
+        <System.ButtonPrimitive
           style={{ marginLeft: 16, color: Constants.semantic.textGray }}
           onClick={hideExtensionBar}
         >
           <SVG.Dismiss width={16} style={{ display: "block" }} />
-        </button>
+        </System.ButtonPrimitive>
       </div>
     </Jumper.Item>
   );
@@ -160,13 +159,27 @@ export function UploadJumper({ data }) {
   const onboardingContext = useUploadOnboardingContext();
 
   const { handleUpload } = useFileUpload({ data, onUpload: onboardingContext?.goToNextStep });
+  const handleSelectFileKeyDown = (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.target.click();
+      e.preventDefault();
+    }
+  };
 
   return (
     <Jumper.AnimatePresence>
       {isUploadJumperVisible ? (
-        <Jumper.Root onClose={() => (onboardingContext.goToNextStep(), hideUploadJumper())}>
+        <Jumper.Root
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="upload-jumper"
+          onClose={() => (onboardingContext.goToNextStep(), hideUploadJumper())}
+        >
           <Jumper.Header>
-            <System.H5 color="textBlack">Upload</System.H5>
+            <System.H5 color="textBlack" id="upload-jumper">
+              Upload
+            </System.H5>
+            <Jumper.Dismiss />
           </Jumper.Header>
           <Jumper.Divider />
           <ExtensionBar />
@@ -193,6 +206,8 @@ export function UploadJumper({ data }) {
               <System.ButtonTertiary
                 type="label"
                 htmlFor="file"
+                tabindex={0}
+                onKeyDown={handleSelectFileKeyDown}
                 style={{
                   marginTop: 23,
                   maxWidth: 122,
@@ -223,6 +238,7 @@ export function MobileUploadJumper({ data }) {
         <MobileJumper.Root onClose={() => (onboardingContext.goToNextStep(), hideUploadJumper())}>
           <MobileJumper.Header>
             <System.H5 color="textBlack">Upload</System.H5>
+            <MobileJumper.Dismiss />
           </MobileJumper.Header>
           <MobileJumper.Divider color="borderGrayLight" />
           <MobileJumper.Content style={{ padding: 0 }}>

--- a/components/core/Upload/index.js
+++ b/components/core/Upload/index.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Styles from "~/common/styles";
 import * as Events from "~/common/custom-events";
+import * as System from "~/components/system";
 
 import { ModalPortal } from "../ModalPortal";
 import { Provider } from "~/components/core/Upload/Provider";
@@ -30,7 +31,7 @@ const Root = ({ children, data, isMobile }) => {
  * Trigger
  * -----------------------------------------------------------------------------------------------*/
 
-const Trigger = ({ viewer, css, children, ...props }) => {
+const Trigger = ({ viewer, children, ...props }) => {
   const onboardingContext = useUploadOnboardingContext();
   const showUploadModal = () => {
     if (onboardingContext) onboardingContext?.goToNextStep?.call();
@@ -44,9 +45,9 @@ const Trigger = ({ viewer, css, children, ...props }) => {
 
   return (
     <div css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
-      <button css={[Styles.BUTTON_RESET, css]} onClick={showUploadModal} {...props}>
+      <System.ButtonPrimitive onClick={showUploadModal} {...props}>
         {children}
-      </button>
+      </System.ButtonPrimitive>
     </div>
   );
 };

--- a/components/system/components/Buttons.js
+++ b/components/system/components/Buttons.js
@@ -2,10 +2,9 @@ import * as React from "react";
 import * as Constants from "~/common/constants";
 
 import { css } from "@emotion/react";
-
 import { LoaderSpinner } from "~/components/system/components/Loaders";
 
-const STYLES_BUTTON = `
+const STYLES_BUTTON = css`
   box-sizing: border-box;
   border-radius: 12px;
   outline: 0;
@@ -54,18 +53,63 @@ const STYLES_BUTTON_PRIMARY_TRANSPARENT = css`
   color: ${Constants.system.blue};
 `;
 
-export const ButtonPrimary = ({
-  children,
-  css,
-  style,
-  full,
-  transparent,
-  loading,
-  label,
-  type,
-  ...props
-}) => {
-  if (loading) {
+export const ButtonPrimary = React.forwardRef(
+  ({ children, css, style, full, transparent, loading, label, type, ...props }, ref) => {
+    if (loading) {
+      return (
+        <button
+          css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={type}
+          ref={ref}
+          {...props}
+        >
+          <LoaderSpinner style={{ height: 16, width: 16, color: Constants.system.white }} />
+        </button>
+      );
+    }
+
+    if (type === "label") {
+      return (
+        <label
+          css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={label}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </label>
+      );
+    }
+
+    if (type === "link") {
+      return (
+        <a
+          css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </a>
+      );
+    }
+
+    if (props.disabled) {
+      return (
+        <button
+          css={[STYLES_BUTTON_PRIMARY_DISABLED, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={type}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </button>
+      );
+    }
+
     return (
       <button
         css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
@@ -73,64 +117,15 @@ export const ButtonPrimary = ({
         type={type}
         {...props}
       >
-        <LoaderSpinner style={{ height: 16, width: 16, color: Constants.system.white }} />
-      </button>
-    );
-  }
-
-  if (type === "label") {
-    return (
-      <label
-        css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={label}
-        {...props}
-      >
-        {children}
-      </label>
-    );
-  }
-
-  if (type === "link") {
-    return (
-      <a
-        css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        {...props}
-      >
-        {children}
-      </a>
-    );
-  }
-
-  if (props.disabled) {
-    return (
-      <button
-        css={[STYLES_BUTTON_PRIMARY_DISABLED, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={type}
-        {...props}
-      >
         {children}
       </button>
     );
   }
+);
 
-  return (
-    <button
-      css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
-      style={{ width: full ? "100%" : "auto", ...style }}
-      type={type}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-};
-
-export const ButtonPrimaryFull = (props) => {
-  return <ButtonPrimary full {...props} />;
-};
+export const ButtonPrimaryFull = React.forwardRef((props, ref) => {
+  return <ButtonPrimary full ref={ref} {...props} />;
+});
 
 const STYLES_BUTTON_SECONDARY = css`
   ${STYLES_BUTTON}
@@ -157,66 +152,62 @@ const STYLES_BUTTON_SECONDARY_TRANSPARENT = css`
   color: ${Constants.system.grayLight2};
 `;
 
-export const ButtonSecondary = ({
-  children,
-  css,
-  style,
-  full,
-  transparent,
-  loading,
-  label,
-  type,
-  ...props
-}) => {
-  if (loading) {
+export const ButtonSecondary = React.forwardRef(
+  ({ children, css, style, full, transparent, loading, label, type, ...props }, ref) => {
+    if (loading) {
+      return (
+        <button
+          css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={type}
+          ref={ref}
+          {...props}
+        >
+          <LoaderSpinner style={{ height: 16, width: 16 }} />
+        </button>
+      );
+    }
+
+    if (type === "label") {
+      return (
+        <label
+          css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={label}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </label>
+      );
+    }
+
+    if (type === "link") {
+      return (
+        <a
+          css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </a>
+      );
+    }
+
     return (
       <button
         css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
         style={{ width: full ? "100%" : "auto", ...style }}
         type={type}
+        ref={ref}
         {...props}
       >
-        <LoaderSpinner style={{ height: 16, width: 16 }} />
+        {children}
       </button>
     );
   }
-
-  if (type === "label") {
-    return (
-      <label
-        css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={label}
-        {...props}
-      >
-        {children}
-      </label>
-    );
-  }
-
-  if (type === "link") {
-    return (
-      <a
-        css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        {...props}
-      >
-        {children}
-      </a>
-    );
-  }
-
-  return (
-    <button
-      css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
-      style={{ width: full ? "100%" : "auto", ...style }}
-      type={type}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-};
+);
 
 export const ButtonSecondaryFull = (props) => {
   return <ButtonSecondary full {...props} />;
@@ -233,11 +224,6 @@ const STYLES_BUTTON_TERTIARY = css`
   :hover {
     background-color: #fcfcfc;
   }
-
-  :focus {
-    outline: 0;
-    border: 0;
-  }
 `;
 
 const STYLES_BUTTON_TERTIARY_TRANSPARENT = css`
@@ -248,69 +234,65 @@ const STYLES_BUTTON_TERTIARY_TRANSPARENT = css`
   color: ${Constants.system.grayLight2};
 `;
 
-export const ButtonTertiary = ({
-  children,
-  css,
-  style,
-  full,
-  transparent,
-  loading,
-  label,
-  type,
-  ...props
-}) => {
-  if (loading) {
+export const ButtonTertiary = React.forwardRef(
+  ({ children, css, style, full, transparent, loading, label, type, ...props }, ref) => {
+    if (loading) {
+      return (
+        <button
+          css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={type}
+          ref={ref}
+          {...props}
+        >
+          <LoaderSpinner style={{ height: 16, width: 16 }} />
+        </button>
+      );
+    }
+
+    if (type === "label") {
+      return (
+        <label
+          css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </label>
+      );
+    }
+
+    if (type === "link") {
+      return (
+        <a
+          css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </a>
+      );
+    }
+
     return (
       <button
         css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
         style={{ width: full ? "100%" : "auto", ...style }}
         type={type}
+        ref={ref}
         {...props}
       >
-        <LoaderSpinner style={{ height: 16, width: 16 }} />
+        {children}
       </button>
     );
   }
+);
 
-  if (type === "label") {
-    return (
-      <label
-        css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        {...props}
-      >
-        {children}
-      </label>
-    );
-  }
-
-  if (type === "link") {
-    return (
-      <a
-        css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        {...props}
-      >
-        {children}
-      </a>
-    );
-  }
-
-  return (
-    <button
-      css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
-      style={{ width: full ? "100%" : "auto", ...style }}
-      type={type}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-};
-
-export const ButtonTertiaryFull = (props) => {
-  return <ButtonTertiary full {...props} />;
-};
+export const ButtonTertiaryFull = React.forwardRef((props, ref) => {
+  return <ButtonTertiary full {...props} ref={ref} />;
+});
 
 const STYLES_BUTTON_DISABLED = css`
   ${STYLES_BUTTON}
@@ -332,22 +314,25 @@ const STYLES_BUTTON_DISABLED_TRANSPARENT = css`
   color: ${Constants.system.gray};
 `;
 
-export const ButtonDisabled = ({ children, css, style, full, label, ...props }) => {
-  return (
-    <button
-      css={[props.transparent ? STYLES_BUTTON_DISABLED_TRANSPARENT : STYLES_BUTTON_DISABLED, css]}
-      type={label}
-      style={{ width: full ? "100%" : "auto", ...style }}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-};
+export const ButtonDisabled = React.forwardRef(
+  ({ children, css, style, full, label, ...props }, ref) => {
+    return (
+      <button
+        css={[props.transparent ? STYLES_BUTTON_DISABLED_TRANSPARENT : STYLES_BUTTON_DISABLED, css]}
+        type={label}
+        style={{ width: full ? "100%" : "auto", ...style }}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
 
-export const ButtonDisabledFull = (props) => {
-  return <ButtonDisabled full {...props} />;
-};
+export const ButtonDisabledFull = React.forwardRef((props, ref) => {
+  return <ButtonDisabled full ref={ref} {...props} />;
+});
 
 const STYLES_BUTTON_WARNING = css`
   ${STYLES_BUTTON}
@@ -380,69 +365,64 @@ const STYLES_BUTTON_WARNING_TRANSPARENT = css`
   color: ${Constants.system.red};
 `;
 
-export const ButtonWarning = ({
-  children,
-  css,
-  style,
-  full,
-  transparent,
-  type,
-  disabled,
-  loading,
-  label,
-  ...props
-}) => {
-  if (loading) {
+export const ButtonWarning = React.forwardRef(
+  ({ children, css, style, full, transparent, type, disabled, loading, label, ...props }, ref) => {
+    if (loading) {
+      return (
+        <button
+          css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={type}
+          ref={ref}
+          {...props}
+        >
+          <LoaderSpinner style={{ height: 16, width: 16, color: Constants.system.white }} />
+        </button>
+      );
+    }
+
+    if (type === "label") {
+      return (
+        <label
+          css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={label}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </label>
+      );
+    }
+
+    if (disabled) {
+      return (
+        <button
+          css={[STYLES_BUTTON_WARNING_DISABLED, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={type}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </button>
+      );
+    }
+
     return (
       <button
         css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
         style={{ width: full ? "100%" : "auto", ...style }}
         type={type}
-        {...props}
-      >
-        <LoaderSpinner style={{ height: 16, width: 16, color: Constants.system.white }} />
-      </button>
-    );
-  }
-
-  if (type === "label") {
-    return (
-      <label
-        css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={label}
-        {...props}
-      >
-        {children}
-      </label>
-    );
-  }
-
-  if (disabled) {
-    return (
-      <button
-        css={[STYLES_BUTTON_WARNING_DISABLED, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={type}
+        ref={ref}
         {...props}
       >
         {children}
       </button>
     );
   }
+);
 
-  return (
-    <button
-      css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
-      style={{ width: full ? "100%" : "auto", ...style }}
-      type={type}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-};
-
-export const ButtonWarningFull = (props) => {
-  return <ButtonWarning full {...props} />;
-};
+export const ButtonWarningFull = React.forwardRef((props, ref) => {
+  return <ButtonWarning full ref={ref} {...props} />;
+});

--- a/components/system/components/Buttons.js
+++ b/components/system/components/Buttons.js
@@ -1,8 +1,19 @@
 import * as React from "react";
 import * as Constants from "~/common/constants";
+import * as Styles from "~/common/styles";
 
 import { css } from "@emotion/react";
 import { LoaderSpinner } from "~/components/system/components/Loaders";
+import { jsx } from "@emotion/react";
+import { FocusRing } from "~/components/core/FocusRing";
+
+export const ButtonPrimitive = React.forwardRef(
+  ({ as = "button", children, css, ...props }, ref) => {
+    return (
+      <FocusRing>{jsx(as, { ...props, css: [Styles.BUTTON_RESET, css], ref }, children)}</FocusRing>
+    );
+  }
+);
 
 const STYLES_BUTTON = css`
   box-sizing: border-box;
@@ -17,7 +28,7 @@ const STYLES_BUTTON = css`
   line-height: 20px;
   letter-spacing: -0.006px;
   font-family: ${Constants.font.medium};
-  transition: 200ms ease all;
+  transition: 200ms ease background-color;
   overflow-wrap: break-word;
   user-select: none;
 `;
@@ -31,11 +42,6 @@ const STYLES_BUTTON_PRIMARY = css`
 
   :hover {
     background-color: #0079eb;
-  }
-
-  :focus {
-    outline: 0;
-    border: 0;
   }
 `;
 
@@ -57,68 +63,78 @@ export const ButtonPrimary = React.forwardRef(
   ({ children, css, style, full, transparent, loading, label, type, ...props }, ref) => {
     if (loading) {
       return (
-        <button
-          css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          type={type}
-          ref={ref}
-          {...props}
-        >
-          <LoaderSpinner style={{ height: 16, width: 16, color: Constants.system.white }} />
-        </button>
+        <FocusRing>
+          <button
+            css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={type}
+            ref={ref}
+            {...props}
+          >
+            <LoaderSpinner style={{ height: 16, width: 16, color: Constants.system.white }} />
+          </button>
+        </FocusRing>
       );
     }
 
     if (type === "label") {
       return (
-        <label
-          css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          type={label}
-          ref={ref}
-          {...props}
-        >
-          {children}
-        </label>
+        <FocusRing>
+          <label
+            css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={label}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </label>
+        </FocusRing>
       );
     }
 
     if (type === "link") {
       return (
-        <a
-          css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          ref={ref}
-          {...props}
-        >
-          {children}
-        </a>
+        <FocusRing>
+          <a
+            css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </a>
+        </FocusRing>
       );
     }
 
     if (props.disabled) {
       return (
-        <button
-          css={[STYLES_BUTTON_PRIMARY_DISABLED, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          type={type}
-          ref={ref}
-          {...props}
-        >
-          {children}
-        </button>
+        <FocusRing>
+          <button
+            css={[STYLES_BUTTON_PRIMARY_DISABLED, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={type}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </button>
+        </FocusRing>
       );
     }
 
     return (
-      <button
-        css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={type}
-        {...props}
-      >
-        {children}
-      </button>
+      <FocusRing>
+        <button
+          css={[transparent ? STYLES_BUTTON_PRIMARY_TRANSPARENT : STYLES_BUTTON_PRIMARY, css]}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          type={type}
+          {...props}
+        >
+          {children}
+        </button>
+      </FocusRing>
     );
   }
 );
@@ -138,11 +154,6 @@ const STYLES_BUTTON_SECONDARY = css`
   :hover {
     background-color: ${Constants.system.grayLight4};
   }
-
-  :focus {
-    outline: 0;
-    border: 0;
-  }
 `;
 
 const STYLES_BUTTON_SECONDARY_TRANSPARENT = css`
@@ -156,6 +167,53 @@ export const ButtonSecondary = React.forwardRef(
   ({ children, css, style, full, transparent, loading, label, type, ...props }, ref) => {
     if (loading) {
       return (
+        <FocusRing>
+          <button
+            css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={type}
+            ref={ref}
+            {...props}
+          >
+            <LoaderSpinner style={{ height: 16, width: 16 }} />
+          </button>
+        </FocusRing>
+      );
+    }
+
+    if (type === "label") {
+      return (
+        <FocusRing>
+          <label
+            css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={label}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </label>
+        </FocusRing>
+      );
+    }
+
+    if (type === "link") {
+      return (
+        <FocusRing>
+          <a
+            css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </a>
+        </FocusRing>
+      );
+    }
+
+    return (
+      <FocusRing>
         <button
           css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
           style={{ width: full ? "100%" : "auto", ...style }}
@@ -163,54 +221,19 @@ export const ButtonSecondary = React.forwardRef(
           ref={ref}
           {...props}
         >
-          <LoaderSpinner style={{ height: 16, width: 16 }} />
+          {children}
         </button>
-      );
-    }
-
-    if (type === "label") {
-      return (
-        <label
-          css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          type={label}
-          ref={ref}
-          {...props}
-        >
-          {children}
-        </label>
-      );
-    }
-
-    if (type === "link") {
-      return (
-        <a
-          css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          ref={ref}
-          {...props}
-        >
-          {children}
-        </a>
-      );
-    }
-
-    return (
-      <button
-        css={[transparent ? STYLES_BUTTON_SECONDARY_TRANSPARENT : STYLES_BUTTON_SECONDARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={type}
-        ref={ref}
-        {...props}
-      >
-        {children}
-      </button>
+      </FocusRing>
     );
   }
 );
 
 export const ButtonSecondaryFull = (props) => {
-  return <ButtonSecondary full {...props} />;
+  return (
+    <FocusRing>
+      <ButtonSecondary full {...props} />
+    </FocusRing>
+  );
 };
 
 const STYLES_BUTTON_TERTIARY = css`
@@ -238,6 +261,52 @@ export const ButtonTertiary = React.forwardRef(
   ({ children, css, style, full, transparent, loading, label, type, ...props }, ref) => {
     if (loading) {
       return (
+        <FocusRing>
+          <button
+            css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={type}
+            ref={ref}
+            {...props}
+          >
+            <LoaderSpinner style={{ height: 16, width: 16 }} />
+          </button>
+        </FocusRing>
+      );
+    }
+
+    if (type === "label") {
+      return (
+        <FocusRing>
+          <label
+            css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </label>
+        </FocusRing>
+      );
+    }
+
+    if (type === "link") {
+      return (
+        <FocusRing>
+          <a
+            css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </a>
+        </FocusRing>
+      );
+    }
+
+    return (
+      <FocusRing>
         <button
           css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
           style={{ width: full ? "100%" : "auto", ...style }}
@@ -245,53 +314,19 @@ export const ButtonTertiary = React.forwardRef(
           ref={ref}
           {...props}
         >
-          <LoaderSpinner style={{ height: 16, width: 16 }} />
+          {children}
         </button>
-      );
-    }
-
-    if (type === "label") {
-      return (
-        <label
-          css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          ref={ref}
-          {...props}
-        >
-          {children}
-        </label>
-      );
-    }
-
-    if (type === "link") {
-      return (
-        <a
-          css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          ref={ref}
-          {...props}
-        >
-          {children}
-        </a>
-      );
-    }
-
-    return (
-      <button
-        css={[transparent ? STYLES_BUTTON_TERTIARY_TRANSPARENT : STYLES_BUTTON_TERTIARY, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={type}
-        ref={ref}
-        {...props}
-      >
-        {children}
-      </button>
+      </FocusRing>
     );
   }
 );
 
 export const ButtonTertiaryFull = React.forwardRef((props, ref) => {
-  return <ButtonTertiary full {...props} ref={ref} />;
+  return (
+    <FocusRing>
+      <ButtonTertiary full {...props} ref={ref} />
+    </FocusRing>
+  );
 });
 
 const STYLES_BUTTON_DISABLED = css`
@@ -300,11 +335,6 @@ const STYLES_BUTTON_DISABLED = css`
   background-color: ${Constants.system.white};
   color: ${Constants.semantic.textGrayLight};
   box-shadow: 0 0 0 1px ${Constants.semantic.bgGrayLight} inset;
-
-  :focus {
-    outline: 0;
-    border: 0;
-  }
 `;
 
 const STYLES_BUTTON_DISABLED_TRANSPARENT = css`
@@ -317,15 +347,20 @@ const STYLES_BUTTON_DISABLED_TRANSPARENT = css`
 export const ButtonDisabled = React.forwardRef(
   ({ children, css, style, full, label, ...props }, ref) => {
     return (
-      <button
-        css={[props.transparent ? STYLES_BUTTON_DISABLED_TRANSPARENT : STYLES_BUTTON_DISABLED, css]}
-        type={label}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        ref={ref}
-        {...props}
-      >
-        {children}
-      </button>
+      <FocusRing>
+        <button
+          css={[
+            props.transparent ? STYLES_BUTTON_DISABLED_TRANSPARENT : STYLES_BUTTON_DISABLED,
+            css,
+          ]}
+          type={label}
+          style={{ width: full ? "100%" : "auto", ...style }}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </button>
+      </FocusRing>
     );
   }
 );
@@ -342,11 +377,6 @@ const STYLES_BUTTON_WARNING = css`
 
   :hover {
     background-color: #b51111;
-  }
-
-  :focus {
-    outline: 0;
-    border: 0;
   }
 `;
 
@@ -369,36 +399,56 @@ export const ButtonWarning = React.forwardRef(
   ({ children, css, style, full, transparent, type, disabled, loading, label, ...props }, ref) => {
     if (loading) {
       return (
-        <button
-          css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          type={type}
-          ref={ref}
-          {...props}
-        >
-          <LoaderSpinner style={{ height: 16, width: 16, color: Constants.system.white }} />
-        </button>
+        <FocusRing>
+          <button
+            css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={type}
+            ref={ref}
+            {...props}
+          >
+            <LoaderSpinner style={{ height: 16, width: 16, color: Constants.system.white }} />
+          </button>
+        </FocusRing>
       );
     }
 
     if (type === "label") {
       return (
-        <label
-          css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
-          style={{ width: full ? "100%" : "auto", ...style }}
-          type={label}
-          ref={ref}
-          {...props}
-        >
-          {children}
-        </label>
+        <FocusRing>
+          <label
+            css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={label}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </label>
+        </FocusRing>
       );
     }
 
     if (disabled) {
       return (
+        <FocusRing>
+          <button
+            css={[STYLES_BUTTON_WARNING_DISABLED, css]}
+            style={{ width: full ? "100%" : "auto", ...style }}
+            type={type}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </button>
+        </FocusRing>
+      );
+    }
+
+    return (
+      <FocusRing>
         <button
-          css={[STYLES_BUTTON_WARNING_DISABLED, css]}
+          css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
           style={{ width: full ? "100%" : "auto", ...style }}
           type={type}
           ref={ref}
@@ -406,23 +456,15 @@ export const ButtonWarning = React.forwardRef(
         >
           {children}
         </button>
-      );
-    }
-
-    return (
-      <button
-        css={[transparent ? STYLES_BUTTON_WARNING_TRANSPARENT : STYLES_BUTTON_WARNING, css]}
-        style={{ width: full ? "100%" : "auto", ...style }}
-        type={type}
-        ref={ref}
-        {...props}
-      >
-        {children}
-      </button>
+      </FocusRing>
     );
   }
 );
 
 export const ButtonWarningFull = React.forwardRef((props, ref) => {
-  return <ButtonWarning full ref={ref} {...props} />;
+  return (
+    <FocusRing>
+      <ButtonWarning full ref={ref} {...props} />
+    </FocusRing>
+  );
 });

--- a/components/system/components/CodeTextarea.js
+++ b/components/system/components/CodeTextarea.js
@@ -19,7 +19,6 @@ const STYLES_CODE_TEXTAREA = css`
   resize: none;
   font-size: 14px;
   box-sizing: border-box;
-  outline: 0;
   border: 0;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
   scrollbar-width: none;

--- a/components/system/components/FullHeightLayout.js
+++ b/components/system/components/FullHeightLayout.js
@@ -13,7 +13,7 @@ const STYLES_FULL_HEIGHT = css`
   height: var(--full-height);
 `;
 
-export function FullHeightLayout({ children, css, as = "div", ...props }) {
+export const FullHeightLayout = React.forwardRef(({ children, css, as = "div", ...props }, ref) => {
   useIsomorphicLayoutEffect(() => {
     if (typeof window === "undefined") return;
     updateCssVarFullHeight();
@@ -24,8 +24,8 @@ export function FullHeightLayout({ children, css, as = "div", ...props }) {
   const Component = as;
 
   return (
-    <Component css={[STYLES_FULL_HEIGHT, css]} {...props}>
+    <Component css={[STYLES_FULL_HEIGHT, css]} ref={ref} {...props}>
       {children}
     </Component>
   );
-}
+});

--- a/components/system/components/GlobalCarousel/index.js
+++ b/components/system/components/GlobalCarousel/index.js
@@ -7,7 +7,7 @@ import * as Jumpers from "~/components/system/components/GlobalCarousel/jumpers"
 import * as Utilities from "~/common/utilities";
 import * as UploadUtilities from "~/common/upload-utilities";
 import * as Validations from "~/common/validations";
-import * as Actions from "~/common/actions";
+import * as Tooltip from "~/components/system/components/fragments/Tooltip";
 import * as Events from "~/common/custom-events";
 
 import { css } from "@emotion/react";
@@ -114,6 +114,24 @@ const SaveFileButton = ({ file, viewer, onAction, ...props }) => {
 
 /* -----------------------------------------------------------------------------------------------*/
 
+const ActionButtonTooltip = ({ label, keyTrigger, id, children }) => {
+  return (
+    <Tooltip.Root vertical="below" horizontal="center">
+      <Tooltip.Trigger aria-labelledby={id}>{children}</Tooltip.Trigger>
+      <Tooltip.Content css={Styles.HORIZONTAL_CONTAINER_CENTERED} style={{ marginTop: 4.5 }}>
+        <System.H6 id={id} as="p" color="textGrayDark">
+          {label}
+        </System.H6>
+        <System.H6 as="p" color="textGray" style={{ marginLeft: 16 }}>
+          {keyTrigger}
+        </System.H6>
+      </Tooltip.Content>
+    </Tooltip.Root>
+  );
+};
+
+/* -----------------------------------------------------------------------------------------------*/
+
 const useCarouselJumperControls = () => {
   const [isControlVisible, setControlVisibility] = React.useState(false);
   const showControl = () => setControlVisibility(true);
@@ -140,9 +158,14 @@ const STYLES_HEADER_WRAPPER = (theme) => css`
   }
 `;
 
-const STYLES_ACTION_BUTTON = css`
+const STYLES_ACTION_BUTTON = (theme) => css`
   ${Styles.BUTTON_RESET};
   padding: 8px;
+  border-radius: 8px;
+  &:hover {
+    background-color: ${theme.semantic.bgGrayLight};
+    box-shadow: ${theme.shadow.lightSmall};
+  }
 `;
 
 function CarouselHeader({
@@ -193,6 +216,28 @@ function CarouselHeader({
     { showControl: showEditChannels, hideControl: hideEditChannels },
   ] = useCarouselJumperControls();
 
+  const handleKeyDown = (e) => {
+    switch (e.key) {
+      case "e":
+      case "E":
+        showEditInfo();
+        break;
+      case "t":
+      case "T":
+        showEditChannels();
+        break;
+      case "s":
+      case "S":
+        showShareFile();
+        break;
+      case "i":
+      case "I":
+        showMoreInfo();
+        break;
+    }
+  };
+  useEventListener({ type: "keyup", handler: handleKeyDown });
+
   const isJumperOpen =
     isFileDescriptionVisible ||
     isMoreInfoVisible ||
@@ -222,8 +267,10 @@ function CarouselHeader({
 
   useIsomorphicLayoutEffect(() => {
     if (isJumperOpen) {
+      showHeader();
       return;
     }
+
     hideHeader();
   }, [isJumperOpen]);
 
@@ -321,24 +368,36 @@ function CarouselHeader({
           <AnimateSharedLayout>
             <div css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
               {isOwner && (
-                <motion.button
-                  layoutId="jumper-desktop-edit"
-                  onClick={showEditInfo}
-                  css={STYLES_ACTION_BUTTON}
+                <ActionButtonTooltip
+                  label="Edit Info"
+                  keyTrigger="E"
+                  id="globalcarousel-editinfo-trigger-tooltip"
                 >
-                  <SVG.Edit style={{ pointerEvents: "none" }} />
-                </motion.button>
+                  <motion.button
+                    layoutId="jumper-desktop-edit"
+                    onClick={showEditInfo}
+                    css={STYLES_ACTION_BUTTON}
+                  >
+                    <SVG.Edit style={{ pointerEvents: "none" }} />
+                  </motion.button>
+                </ActionButtonTooltip>
               )}
 
               {isOwner && (
-                <motion.button
-                  layoutId="jumper-desktop-channels"
-                  onClick={showEditChannels}
-                  style={{ marginLeft: 4 }}
-                  css={STYLES_ACTION_BUTTON}
+                <ActionButtonTooltip
+                  label="Tag"
+                  keyTrigger="T"
+                  id="globalcarousel-tag-trigger-tooltip"
                 >
-                  <SVG.Hash style={{ pointerEvents: "none" }} />
-                </motion.button>
+                  <motion.button
+                    layoutId="jumper-desktop-channels"
+                    onClick={showEditChannels}
+                    style={{ marginLeft: 4 }}
+                    css={STYLES_ACTION_BUTTON}
+                  >
+                    <SVG.Hash style={{ pointerEvents: "none" }} />
+                  </motion.button>
+                </ActionButtonTooltip>
               )}
 
               {!isOwner && (
@@ -351,23 +410,35 @@ function CarouselHeader({
                 />
               )}
 
-              <motion.button
-                layoutId="jumper-desktop-share"
-                onClick={showShareFile}
-                style={{ marginLeft: 4 }}
-                css={STYLES_ACTION_BUTTON}
+              <ActionButtonTooltip
+                label="Share"
+                keyTrigger="S"
+                id="globalcarousel-share-trigger-tooltip"
               >
-                <SVG.Share style={{ pointerEvents: "none" }} />
-              </motion.button>
+                <motion.button
+                  layoutId="jumper-desktop-share"
+                  onClick={showShareFile}
+                  style={{ marginLeft: 4 }}
+                  css={STYLES_ACTION_BUTTON}
+                >
+                  <SVG.Share style={{ pointerEvents: "none" }} />
+                </motion.button>
+              </ActionButtonTooltip>
 
-              <motion.button
-                layoutId="jumper-desktop-info"
-                onClick={showMoreInfo}
-                style={{ marginLeft: 4 }}
-                css={STYLES_ACTION_BUTTON}
+              <ActionButtonTooltip
+                label="More info"
+                keyTrigger="I"
+                id="globalcarousel-info-trigger-tooltip"
               >
-                <SVG.InfoCircle style={{ pointerEvents: "none" }} />
-              </motion.button>
+                <motion.button
+                  layoutId="jumper-desktop-info"
+                  onClick={showMoreInfo}
+                  style={{ marginLeft: 4 }}
+                  css={STYLES_ACTION_BUTTON}
+                >
+                  <SVG.InfoCircle style={{ pointerEvents: "none" }} />
+                </motion.button>
+              </ActionButtonTooltip>
 
               {file.isLink ? <VisitLinkButton file={file} /> : null}
             </div>

--- a/components/system/components/GlobalCarousel/jumpers/EditChannels.js
+++ b/components/system/components/GlobalCarousel/jumpers/EditChannels.js
@@ -10,6 +10,7 @@ import * as MobileJumper from "~/components/system/components/fragments/MobileJu
 import * as Strings from "~/common/strings";
 import * as Validations from "~/common/validations";
 import * as Events from "~/common/custom-events";
+import * as RovingTabIndex from "~/components/core/RovingTabIndex";
 
 import { Show } from "~/components/utility/Show";
 import { css } from "@emotion/react";
@@ -31,10 +32,11 @@ const STYLES_CHANNEL_BUTTON_SELECTED = (theme) => css`
   background-color: ${theme.semantic.bgGrayLight4};
 `;
 
-function ChannelButton({ children, isSelected, css, ...props }) {
+const ChannelButton = React.forwardRef(({ children, isSelected, css, ...props }, ref) => {
   return (
     <System.ButtonPrimitive
       {...props}
+      ref={ref}
       css={[STYLES_CHANNEL_BUTTON, isSelected && STYLES_CHANNEL_BUTTON_SELECTED, css]}
     >
       <System.P2 nbrOflines={1} as="span">
@@ -42,7 +44,7 @@ function ChannelButton({ children, isSelected, css, ...props }) {
       </System.P2>
     </System.ButtonPrimitive>
   );
-}
+});
 
 /* -----------------------------------------------------------------------------------------------*/
 
@@ -200,43 +202,49 @@ function Channels({
       </Show>
 
       <AnimateSharedLayout>
-        <div css={STYLES_CHANNEL_BUTTONS_WRAPPER}>
-          {channels.map((channel) => (
-            <motion.div layoutId={`jumper-${channel.id}`} initial={false} key={channel.id}>
-              <ChannelButton
-                isSelected={channel.doesContainFile}
-                onClick={() => onAddFileToChannel(channel, channel.doesContainFile)}
-                title={channel.slatename}
-                style={{ maxWidth: "48ch" }}
-              >
-                {channel.slatename}
-              </ChannelButton>
-            </motion.div>
-          ))}
+        <RovingTabIndex.Provider axis="horizontal">
+          <RovingTabIndex.List>
+            <div css={STYLES_CHANNEL_BUTTONS_WRAPPER}>
+              {channels.map((channel, index) => (
+                <motion.div layoutId={`jumper-${channel.id}`} initial={false} key={channel.id}>
+                  <RovingTabIndex.Item index={index}>
+                    <ChannelButton
+                      isSelected={channel.doesContainFile}
+                      onClick={() => onAddFileToChannel(channel, channel.doesContainFile)}
+                      title={channel.slatename}
+                      style={{ maxWidth: "48ch" }}
+                    >
+                      {channel.slatename}
+                    </ChannelButton>
+                  </RovingTabIndex.Item>
+                </motion.div>
+              ))}
 
-          <Show when={isCreatingChannel}>
-            <motion.div initial={{ opacity: 0.5, y: 4 }} animate={{ opacity: 1, y: 0 }}>
-              <ChannelButton
-                css={Styles.HORIZONTAL_CONTAINER_CENTERED}
-                onClick={(e) => (e.stopPropagation(), onCreateChannel(searchQuery))}
-                title={searchQuery}
-              >
-                <SVG.Plus
-                  width={16}
-                  height={16}
-                  style={{
-                    position: "relative",
-                    top: -1,
-                    verticalAlign: "middle",
-                    pointerEvents: "none",
-                    display: "inline",
-                  }}
-                />
-                <span style={{ marginLeft: 4 }}>{searchQuery}</span>
-              </ChannelButton>
-            </motion.div>
-          </Show>
-        </div>
+              <Show when={isCreatingChannel}>
+                <motion.div initial={{ opacity: 0.5, y: 4 }} animate={{ opacity: 1, y: 0 }}>
+                  <ChannelButton
+                    css={Styles.HORIZONTAL_CONTAINER_CENTERED}
+                    onClick={(e) => (e.stopPropagation(), onCreateChannel(searchQuery))}
+                    title={searchQuery}
+                  >
+                    <SVG.Plus
+                      width={16}
+                      height={16}
+                      style={{
+                        position: "relative",
+                        top: -1,
+                        verticalAlign: "middle",
+                        pointerEvents: "none",
+                        display: "inline",
+                      }}
+                    />
+                    <span style={{ marginLeft: 4 }}>{searchQuery}</span>
+                  </ChannelButton>
+                </motion.div>
+              </Show>
+            </div>
+          </RovingTabIndex.List>
+        </RovingTabIndex.Provider>
       </AnimateSharedLayout>
     </div>
   ) : null;

--- a/components/system/components/GlobalCarousel/jumpers/EditChannels.js
+++ b/components/system/components/GlobalCarousel/jumpers/EditChannels.js
@@ -203,25 +203,25 @@ function Channels({
 
       <AnimateSharedLayout>
         <RovingTabIndex.Provider axis="horizontal">
-          <RovingTabIndex.List>
-            <div css={STYLES_CHANNEL_BUTTONS_WRAPPER}>
-              {channels.map((channel, index) => (
-                <motion.div layoutId={`jumper-${channel.id}`} initial={false} key={channel.id}>
-                  <RovingTabIndex.Item index={index}>
-                    <ChannelButton
-                      isSelected={channel.doesContainFile}
-                      onClick={() => onAddFileToChannel(channel, channel.doesContainFile)}
-                      title={channel.slatename}
-                      style={{ maxWidth: "48ch" }}
-                    >
-                      {channel.slatename}
-                    </ChannelButton>
-                  </RovingTabIndex.Item>
-                </motion.div>
-              ))}
+          <RovingTabIndex.List css={STYLES_CHANNEL_BUTTONS_WRAPPER}>
+            {channels.map((channel, index) => (
+              <motion.div layoutId={`jumper-${channel.id}`} initial={false} key={channel.id}>
+                <RovingTabIndex.Item index={index}>
+                  <ChannelButton
+                    isSelected={channel.doesContainFile}
+                    onClick={() => onAddFileToChannel(channel, channel.doesContainFile)}
+                    title={channel.slatename}
+                    style={{ maxWidth: "48ch" }}
+                  >
+                    {channel.slatename}
+                  </ChannelButton>
+                </RovingTabIndex.Item>
+              </motion.div>
+            ))}
 
-              <Show when={isCreatingChannel}>
-                <motion.div initial={{ opacity: 0.5, y: 4 }} animate={{ opacity: 1, y: 0 }}>
+            <Show when={isCreatingChannel}>
+              <motion.div initial={{ opacity: 0.5, y: 4 }} animate={{ opacity: 1, y: 0 }}>
+                <RovingTabIndex.Item index={channels.length}>
                   <ChannelButton
                     css={Styles.HORIZONTAL_CONTAINER_CENTERED}
                     onClick={(e) => (e.stopPropagation(), onCreateChannel(searchQuery))}
@@ -240,9 +240,9 @@ function Channels({
                     />
                     <span style={{ marginLeft: 4 }}>{searchQuery}</span>
                   </ChannelButton>
-                </motion.div>
-              </Show>
-            </div>
+                </RovingTabIndex.Item>
+              </motion.div>
+            </Show>
           </RovingTabIndex.List>
         </RovingTabIndex.Provider>
       </AnimateSharedLayout>

--- a/components/system/components/GlobalCarousel/jumpers/EditChannels.js
+++ b/components/system/components/GlobalCarousel/jumpers/EditChannels.js
@@ -19,7 +19,6 @@ import { useEventListener } from "~/common/hooks";
 
 const STYLES_CHANNEL_BUTTON = (theme) => css`
   position: relative;
-  ${Styles.BUTTON_RESET};
   padding: 5px 12px 7px;
   border: 1px solid ${theme.semantic.borderGrayLight4};
   border-radius: 12px;
@@ -34,14 +33,14 @@ const STYLES_CHANNEL_BUTTON_SELECTED = (theme) => css`
 
 function ChannelButton({ children, isSelected, css, ...props }) {
   return (
-    <button
+    <System.ButtonPrimitive
       {...props}
       css={[STYLES_CHANNEL_BUTTON, isSelected && STYLES_CHANNEL_BUTTON_SELECTED, css]}
     >
       <System.P2 nbrOflines={1} as="span">
         {children}
       </System.P2>
-    </button>
+    </System.ButtonPrimitive>
   );
 }
 
@@ -65,7 +64,7 @@ function ChannelKeyboardShortcut({ searchResults, searchQuery, onAddFileToChanne
   const selectedChannel = [...publicChannels, ...privateChannels][0];
 
   useEventListener({
-    type: "keyup",
+    type: "keydown",
     handler: (e) => {
       if (e.key === "Enter") {
         onAddFileToChannel(selectedChannel, selectedChannel.doesContainFile);
@@ -97,11 +96,17 @@ const STYLES_SEARCH_TAGS_INPUT = (theme) => css`
   background-color: transparent;
   ${theme.semantic.textGray};
   box-shadow: none;
-  height: 43px;
+  height: 52px;
   padding: 0px;
   ::placeholder {
     color: ${theme.semantic.textGray};
   }
+`;
+
+const STYLES_SEARCH_TAGS_INPUT_WRAPPER = (theme) => css`
+  color: ${theme.semantic.textGray};
+  width: 100%;
+  margin: 1px;
 `;
 
 function ChannelInput({ value, searchResults, onChange, onAddFileToChannel, ...props }) {
@@ -109,24 +114,27 @@ function ChannelInput({ value, searchResults, onChange, onAddFileToChannel, ...p
   const showShortcut = publicChannels.length + privateChannels.length === 1;
 
   return (
-    <div style={{ position: "relative", width: "100%" }}>
-      <System.Input
-        full
-        value={value}
-        onChange={onChange}
-        name="search"
-        placeholder="Search or create a new tag"
-        inputCss={STYLES_SEARCH_TAGS_INPUT}
-        {...props}
-      />
-      <div style={{ position: "absolute", top: "50%", transform: "translateY(-50%)", right: 20 }}>
-        {showShortcut ? (
-          <ChannelKeyboardShortcut
-            searchQuery={value}
-            searchResults={searchResults}
-            onAddFileToChannel={onAddFileToChannel}
-          />
-        ) : null}
+    <div css={[STYLES_SEARCH_TAGS_INPUT_WRAPPER, Styles.CONTAINER_CENTERED]}>
+      <SVG.Hash width={16} />
+      <div style={{ position: "relative", width: "100%" }}>
+        <System.Input
+          full
+          value={value}
+          onChange={onChange}
+          name="search"
+          placeholder="Search or create a new tag"
+          inputCss={STYLES_SEARCH_TAGS_INPUT}
+          {...props}
+        />
+        <div style={{ position: "absolute", top: "50%", transform: "translateY(-50%)", right: 20 }}>
+          {showShortcut ? (
+            <ChannelKeyboardShortcut
+              searchQuery={value}
+              searchResults={searchResults}
+              onAddFileToChannel={onAddFileToChannel}
+            />
+          ) : null}
+        </div>
       </div>
     </div>
   );
@@ -357,10 +365,6 @@ const useChannelsSearch = ({ privateChannels, publicChannels }) => {
   ];
 };
 
-const STYLES_EDIT_CHANNELS_HEADER = (theme) => css`
-  color: ${theme.semantic.textGray};
-`;
-
 export function EditChannels({ file, viewer, isOpen, onClose, ...props }) {
   const [channels, { handleAddFileToChannel, handleCreateChannel }] = useChannels({
     viewer,
@@ -386,11 +390,7 @@ export function EditChannels({ file, viewer, isOpen, onClose, ...props }) {
     <Jumper.AnimatePresence>
       {isOpen ? (
         <Jumper.Root onClose={() => (onClose(), clearQuery())} {...props}>
-          <Jumper.Header
-            css={[STYLES_EDIT_CHANNELS_HEADER, Styles.CONTAINER_CENTERED]}
-            style={{ paddingTop: 0, paddingBottom: 0 }}
-          >
-            <SVG.Hash width={16} />
+          <Jumper.Header style={{ paddingTop: 0, paddingBottom: 0 }}>
             <ChannelInput
               value={searchQuery}
               onChange={handleQueryChange}
@@ -398,6 +398,7 @@ export function EditChannels({ file, viewer, isOpen, onClose, ...props }) {
               autoFocus
               onAddFileToChannel={handleAddFileToChannel}
             />
+            <Jumper.Dismiss />
           </Jumper.Header>
           <Jumper.Divider />
           <Jumper.Item>
@@ -462,18 +463,15 @@ export function EditChannelsMobile({ file, viewer, isOpen, onClose }) {
     <MobileJumper.AnimatePresence>
       {isOpen ? (
         <MobileJumper.Root onClose={onClose}>
-          <MobileJumper.Header
-            style={{ paddingTop: 0, paddingBottom: 0 }}
-            css={STYLES_EDIT_CHANNELS_HEADER}
-          >
-            <SVG.Hash width={16} />
+          <MobileJumper.Header style={{ paddingTop: 0, paddingBottom: 0 }}>
             <ChannelInput
               value={searchQuery}
               onChange={handleQueryChange}
               searchResults={searchResults}
               onAddFileToChannel={handleAddFileToChannel}
-              autoFocus={viewer?.slates?.length === 0}
+              autoFocus
             />
+            <MobileJumper.Dismiss />
           </MobileJumper.Header>
           <System.Divider height={1} color="borderGrayLight4" />
           <div style={{ padding: "13px 16px 11px" }}>
@@ -502,13 +500,9 @@ export function EditChannelsMobile({ file, viewer, isOpen, onClose }) {
             </div>
           </MobileJumper.Content>
           <MobileJumper.Footer css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
-            <button
-              type="button"
-              css={Styles.BUTTON_RESET}
-              onClick={() => (onClose(), clearQuery())}
-            >
+            <System.ButtonPrimitive type="button" onClick={() => (onClose(), clearQuery())}>
               <SVG.Hash width={16} height={16} style={{ color: Constants.system.blue }} />
-            </button>
+            </System.ButtonPrimitive>
           </MobileJumper.Footer>
         </MobileJumper.Root>
       ) : null}

--- a/components/system/components/GlobalCarousel/jumpers/EditInfo.js
+++ b/components/system/components/GlobalCarousel/jumpers/EditInfo.js
@@ -78,6 +78,7 @@ function UpdateFileForm({ file, isMobile, onClose }) {
             <Field
               full
               inputCss={STYLES_EDIT_INFO_INPUT}
+              autoFocus
               style={{ marginTop: 6 }}
               {...getFieldProps("title")}
             />
@@ -97,14 +98,13 @@ function UpdateFileForm({ file, isMobile, onClose }) {
 
         {isMobile ? (
           <MobileJumper.Footer css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
-            <button
+            <System.ButtonPrimitive
               type="button"
-              css={Styles.BUTTON_RESET}
               style={{ width: 32, height: 32 }}
               onClick={onClose}
             >
               <SVG.Edit width={16} height={16} style={{ color: Constants.system.blue }} />
-            </button>
+            </System.ButtonPrimitive>
             <div css={Styles.HORIZONTAL_CONTAINER_CENTERED} style={{ marginLeft: "auto" }}>
               <System.ButtonSecondary
                 type="button"
@@ -167,6 +167,7 @@ export function EditInfo({ file, isOpen, onClose }) {
         <Jumper.Root onClose={onClose}>
           <Jumper.Header>
             <System.H5 color="textBlack">Edit info</System.H5>
+            <Jumper.Dismiss />
           </Jumper.Header>
           <Jumper.Divider />
           <Jumper.Item>
@@ -189,6 +190,7 @@ export function EditInfoMobile({ file, isOpen, onClose }) {
             <System.H5 as="p" color="textBlack">
               Edit Info
             </System.H5>
+            <MobileJumper.Dismiss />
           </MobileJumper.Header>
           <System.Divider height={1} color="borderGrayLight4" />
           <div style={{ padding: "13px 16px 11px" }}>

--- a/components/system/components/GlobalCarousel/jumpers/FileDescription.js
+++ b/components/system/components/GlobalCarousel/jumpers/FileDescription.js
@@ -13,23 +13,27 @@ export function FileDescription({ file, isOpen, onClose }) {
       {isOpen ? (
         <Jumper.Root onClose={onClose}>
           <Jumper.Header>
-            <System.H3 as="h1" nbrOflines={1} title={file.name || file.filename}>
-              {file.name || file.filename}
-            </System.H3>
-            <Show when={file.isLink}>
-              <div style={{ marginTop: 5 }} css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
-                <LinkIcon file={file} width={12} height={12} />
-                <System.P2
-                  as="p"
-                  nbrOflines={1}
-                  href={file.url}
-                  css={Styles.LINK}
-                  style={{ marginLeft: 5 }}
-                >
-                  {file.url}
-                </System.P2>
-              </div>
-            </Show>
+            <div>
+              <System.H3 as="h1" nbrOflines={1} title={file.name || file.filename}>
+                {file.name || file.filename}
+              </System.H3>
+              <Show when={file.isLink}>
+                <div style={{ marginTop: 5 }} css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
+                  <LinkIcon file={file} width={12} height={12} />
+                  <System.P2
+                    as="a"
+                    nbrOflines={1}
+                    href={file.url}
+                    target="_blank"
+                    css={Styles.LINK}
+                    style={{ marginLeft: 5 }}
+                  >
+                    {file.url}
+                  </System.P2>
+                </div>
+              </Show>
+            </div>
+            <Jumper.Dismiss autoFocus />
           </Jumper.Header>
           <Jumper.Divider />
           <Jumper.Item>

--- a/components/system/components/GlobalCarousel/jumpers/MoreInfo.js
+++ b/components/system/components/GlobalCarousel/jumpers/MoreInfo.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import * as React from "react";
 import * as Styles from "~/common/styles";
 import * as System from "~/components/system";
@@ -18,6 +19,7 @@ import { Show } from "~/components/utility/Show";
 import { css } from "@emotion/react";
 import { useEventListener } from "~/common/hooks";
 import { AnimatePresence, motion } from "framer-motion";
+import { FocusRing } from "~/components/core/FocusRing";
 
 const useCoverImgDrop = ({ onUpload, enabled, ref }) => {
   const [isDropping, setDroppingState] = React.useState(false);
@@ -168,83 +170,94 @@ function CoverImageUpload({ file, viewer, isMobile, isFileOwner }) {
   };
 
   return (
-    <label
-      ref={coverImgDropzoneRef}
-      style={{
-        marginTop: 14,
-        cursor: !isUploadingCoverImg && isFileOwner ? "pointer" : "unset",
-      }}
-    >
-      <div css={Styles.HORIZONTAL_CONTAINER_CENTERED} style={{ justifyContent: "space-between" }}>
-        <System.H6 color="textGray">Preview image</System.H6>
-        <Show when={isFileOwner}>
-          {isUploadingCoverImg ? (
-            <LoaderSpinner style={{ height: 16, width: 16 }} />
-          ) : (
-            <div>
-              <input
-                css={STYLES_FILE_HIDDEN}
-                type="file"
-                id="file"
-                disabled={!isFileOwner || isUploadingCoverImg}
-                onChange={handleInputChange}
-              />
-              <div
-                style={{
-                  display: "block",
-                  color: System.Constants.semantic.textBlack,
-                }}
-              >
-                <SVG.UploadCloud style={{ display: "block" }} width={16} height={16} />
+    <FocusRing within>
+      <label
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={isFileOwner || isUploadingCoverImg ? 0 : -1}
+        ref={coverImgDropzoneRef}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.target.click();
+            e.preventDefault();
+          }
+        }}
+        style={{
+          marginTop: 14,
+          cursor: !isUploadingCoverImg && isFileOwner ? "pointer" : "unset",
+        }}
+      >
+        <div css={Styles.HORIZONTAL_CONTAINER_CENTERED} style={{ justifyContent: "space-between" }}>
+          <System.H6 color="textGray">Preview image</System.H6>
+          <Show when={isFileOwner}>
+            {isUploadingCoverImg ? (
+              <LoaderSpinner style={{ height: 16, width: 16 }} />
+            ) : (
+              <div>
+                <div
+                  style={{
+                    display: "block",
+                    color: System.Constants.semantic.textBlack,
+                  }}
+                >
+                  <SVG.UploadCloud style={{ display: "block" }} width={16} height={16} />
+                </div>
               </div>
+            )}
+          </Show>
+        </div>
+        <div style={{ position: "relative" }}>
+          {coverImage ? (
+            <>
+              <div css={STYLES_IMAGE_PREVIEW}>
+                <img src={Strings.getURLfromCID(coverImage.cid)} alt="" />
+              </div>
+            </>
+          ) : (
+            <div
+              css={[STYLES_IMAGE_PREVIEW, Styles.CONTAINER_CENTERED]}
+              style={{ flexDirection: "column" }}
+            >
+              {isFileOwner ? (
+                <>
+                  <input
+                    css={STYLES_FILE_HIDDEN}
+                    type="file"
+                    id="file"
+                    disabled={isUploadingCoverImg}
+                    onChange={handleInputChange}
+                    tabIndex="-1"
+                  />
+                  <SVG.UploadCloud width={16} />
+                  <System.P3 style={{ maxWidth: 140, textAlign: "center", marginTop: 8 }}>
+                    {isMobile
+                      ? "Select an image as object preview"
+                      : "Drop or select an image as object preview"}
+                  </System.P3>
+                </>
+              ) : (
+                <System.P3 style={{ maxWidth: 140, textAlign: "center", marginTop: 8 }}>
+                  No preview image
+                </System.P3>
+              )}
             </div>
           )}
-        </Show>
-      </div>
-      <div style={{ position: "relative" }}>
-        {coverImage ? (
-          <>
-            <div css={STYLES_IMAGE_PREVIEW}>
-              <img src={Strings.getURLfromCID(coverImage.cid)} alt="" />
-            </div>
-          </>
-        ) : (
-          <div
-            css={[STYLES_IMAGE_PREVIEW, Styles.CONTAINER_CENTERED]}
-            style={{ flexDirection: "column" }}
-          >
-            {isFileOwner ? (
-              <>
-                <SVG.UploadCloud width={16} />
-                <System.P3 style={{ maxWidth: 140, textAlign: "center", marginTop: 8 }}>
-                  {isMobile
-                    ? "Select an image as object preview"
-                    : "Drop or select an image as object preview"}
-                </System.P3>
-              </>
-            ) : (
-              <System.P3 style={{ maxWidth: 140, textAlign: "center", marginTop: 8 }}>
-                No preview image
-              </System.P3>
-            )}
-          </div>
-        )}
 
-        <AnimatePresence>
-          {isDroppingCoverImg ? (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.3, ease: "easeInOut" }}
-              css={STYLES_COVER_IMG_DROP}
-            >
-              <System.P3 color="textGrayDark">Drop the image to upload</System.P3>
-            </motion.div>
-          ) : null}
-        </AnimatePresence>
-      </div>
-    </label>
+          <AnimatePresence>
+            {isDroppingCoverImg ? (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+                css={STYLES_COVER_IMG_DROP}
+              >
+                <System.P3 color="textGrayDark">Drop the image to upload</System.P3>
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </div>
+      </label>
+    </FocusRing>
   );
 }
 
@@ -356,11 +369,12 @@ export function MoreInfo({ external, viewer, isOwner, file, isOpen, onClose }) {
         <Jumper.Root onClose={onClose}>
           <Jumper.Header>
             <System.H5 color="textBlack">More info</System.H5>
+            <Jumper.Dismiss autoFocus />
           </Jumper.Header>
           <Jumper.Divider />
           <Jumper.Item
             css={Styles.HORIZONTAL_CONTAINER}
-            style={{ flexGrow: 1, paddingTop: 0, paddingBottom: 0 }}
+            style={{ paddingTop: 0, paddingBottom: 0 }}
           >
             <CoverImageUpload file={file} viewer={viewer} isFileOwner={isFileOwner} />
             <System.Divider
@@ -388,6 +402,7 @@ export function MoreInfoMobile({ external, viewer, isOwner, file, isOpen, onClos
             <System.H5 as="p" color="textBlack">
               More Info
             </System.H5>
+            <MobileJumper.Dismiss />
           </MobileJumper.Header>
           <System.Divider height={1} color="borderGrayLight4" />
           <div style={{ padding: "13px 16px 11px" }}>
@@ -399,14 +414,13 @@ export function MoreInfoMobile({ external, viewer, isOwner, file, isOpen, onClos
             <FileMetadata file={file} style={{ marginTop: 22 }} />
           </MobileJumper.Content>
           <MobileJumper.Footer css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
-            <button
+            <System.ButtonPrimitive
               type="button"
-              css={Styles.BUTTON_RESET}
               style={{ width: 32, height: 32 }}
               onClick={onClose}
             >
               <SVG.InfoCircle width={16} height={16} style={{ color: Constants.system.blue }} />
-            </button>
+            </System.ButtonPrimitive>
           </MobileJumper.Footer>
         </MobileJumper.Root>
       ) : null}

--- a/components/system/components/GlobalCarousel/jumpers/Share.js
+++ b/components/system/components/GlobalCarousel/jumpers/Share.js
@@ -15,7 +15,6 @@ import { LoaderSpinner } from "~/components/system/components/Loaders";
 /* -----------------------------------------------------------------------------------------------*/
 
 const STYLES_SHARING_BUTTON = (theme) => css`
-  ${Styles.BUTTON_RESET};
   ${Styles.HORIZONTAL_CONTAINER_CENTERED};
   padding: 9px 8px 11px;
   border-radius: 12px;
@@ -59,26 +58,26 @@ function FileSharingButtons({ file, data, viewer }) {
 
   return (
     <>
-      <button css={STYLES_SHARING_BUTTON} onClick={handleTwitterSharing}>
+      <System.ButtonPrimitive css={STYLES_SHARING_BUTTON} onClick={handleTwitterSharing} autoFocus>
         <SVG.Twitter width={16} />
         <System.P2 style={{ marginLeft: 12 }}>Share via Twitter</System.P2>
-      </button>
-      <button css={STYLES_SHARING_BUTTON} onClick={handleEmailSharing}>
+      </System.ButtonPrimitive>
+      <System.ButtonPrimitive css={STYLES_SHARING_BUTTON} onClick={handleEmailSharing}>
         <SVG.Mail width={16} />
         <System.P2 style={{ marginLeft: 12 }}>Share via email </System.P2>
-      </button>
-      <button css={STYLES_SHARING_BUTTON} onClick={handleLinkCopy}>
+      </System.ButtonPrimitive>
+      <System.ButtonPrimitive css={STYLES_SHARING_BUTTON} onClick={handleLinkCopy}>
         <SVG.Link width={16} />
         <System.P2 style={{ marginLeft: 12 }}>
           {copyState.isLinkCopied ? "Copied" : "Copy public link"}
         </System.P2>
-      </button>
-      <button css={STYLES_SHARING_BUTTON} onClick={handleCidCopy}>
+      </System.ButtonPrimitive>
+      <System.ButtonPrimitive css={STYLES_SHARING_BUTTON} onClick={handleCidCopy}>
         <SVG.Hexagon width={16} />
         <System.P2 style={{ marginLeft: 12 }}>
           {copyState.isCidCopied ? "Copied" : "Copy CID "}
         </System.P2>
-      </button>
+      </System.ButtonPrimitive>
       <DownloadButton file={file} viewer={viewer} />
     </>
   );
@@ -111,14 +110,14 @@ function DownloadButton({ file, viewer, ...props }) {
 
   return !file.isLink ? (
     <div ref={downloadRef}>
-      <button css={STYLES_SHARING_BUTTON} onClick={handleDownload} {...props}>
+      <System.ButtonPrimitive css={STYLES_SHARING_BUTTON} onClick={handleDownload} {...props}>
         {isDownloading ? (
           <LoaderSpinner style={{ height: 16, width: 16 }} />
         ) : (
           <SVG.Download width={16} />
         )}
         <System.P2 style={{ marginLeft: 12 }}>Download file</System.P2>
-      </button>
+      </System.ButtonPrimitive>
     </div>
   ) : null;
 }
@@ -145,6 +144,7 @@ export function Share({ file, data, viewer, isOpen, onClose }) {
         <Jumper.Root onClose={onClose}>
           <Jumper.Header>
             <System.H5 color="textBlack">Share</System.H5>
+            <Jumper.Dismiss />
           </Jumper.Header>
           <Jumper.Divider />
           <Jumper.Item>
@@ -181,6 +181,7 @@ export function ShareMobile({ file, data, viewer, isOpen, onClose }) {
             <System.H5 as="p" color="textBlack">
               Share
             </System.H5>
+            <MobileJumper.Dismiss />
           </MobileJumper.Header>
           <System.Divider height={1} color="borderGrayLight4" />
           <div style={{ padding: "13px 16px 11px" }}>
@@ -191,14 +192,13 @@ export function ShareMobile({ file, data, viewer, isOpen, onClose }) {
             <FileSharingButtons file={file} data={data} viewer={viewer} />
           </MobileJumper.Content>
           <MobileJumper.Footer css={Styles.HORIZONTAL_CONTAINER_CENTERED}>
-            <button
+            <System.ButtonPrimitive
               type="button"
-              css={Styles.BUTTON_RESET}
               style={{ width: 32, height: 32 }}
               onClick={onClose}
             >
               <SVG.Share width={16} height={16} style={{ color: Constants.system.blue }} />
-            </button>
+            </System.ButtonPrimitive>
             <a
               css={[Styles.LINK, Styles.HORIZONTAL_CONTAINER_CENTERED]}
               style={{ marginLeft: "auto", color: Constants.semantic.textGrayDark }}

--- a/components/system/components/Input.js
+++ b/components/system/components/Input.js
@@ -4,8 +4,8 @@ import * as SVG from "~/common/svg";
 import * as Strings from "~/common/strings";
 
 import { css } from "@emotion/react";
-
 import { DescriptionGroup } from "~/components/system/components/fragments/DescriptionGroup";
+import { FocusRing } from "~/components/core/FocusRing";
 
 const INPUT_STYLES = css`
   box-sizing: border-box;
@@ -21,10 +21,6 @@ const INPUT_STYLES = css`
   border: none;
   box-sizing: border-box;
   transition: 200ms ease all;
-
-  :focus {
-    outline: 0;
-  }
 
   ::placeholder {
     /* Chrome, Firefox, Opera, Safari 10.1+ */
@@ -180,9 +176,9 @@ export class Input extends React.Component {
     this.props.onSubmit(e);
   };
 
-  _handleKeyUp = (e) => {
-    if (this.props.onKeyUp) {
-      this.props.onKeyUp(e);
+  _handleKeyDown = (e) => {
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(e);
     }
 
     if ((e.which === 13 || e.keyCode === 13) && this.props.onSubmit) {
@@ -232,72 +228,74 @@ export class Input extends React.Component {
             style={this.props.descriptionStyle}
             description={this.props.description}
           />
-          <div
-            css={[STYLES_INPUT, this.props.inputCss]}
-            style={{
-              position: "relative",
-              boxShadow: this.props.validation
-                ? `0 1px 4px rgba(0, 0, 0, 0.07), inset 0 0 0 2px ${
-                    INPUT_COLOR_MAP[this.props.validation]
-                  }`
-                : null,
-              ...this.props.style,
-            }}
-          >
-            <input
-              ref={(c) => {
-                this._input = c;
-              }}
-              css={[INPUT_STYLES, this._isPin && STYLES_PIN_INPUT]}
-              autoFocus={this.props.autoFocus}
-              value={this._isPin ? this._formatPin(this.props.value) : this.props.value}
-              name={this.props.name}
-              type={this._isPin ? "text" : this.props.type}
-              placeholder={this.props.placeholder}
-              onChange={this._handleChange}
-              onFocus={
-                this.props.autoHighlight
-                  ? () => {
-                      this._input.select();
-                    }
-                  : this.props.onFocus
-              }
-              onBlur={this.props.onBlur}
-              onKeyUp={this._handleKeyUp}
-              autoComplete="off"
-              disabled={this.props.disabled}
-              readOnly={this.props.readOnly}
-              required={this.props.required}
-              maxLength={this.props.maxLength}
-              style={{
-                width: this.props.copyable || this.props.icon ? "calc(100% - 32px)" : "100%",
-                ...this.props.textStyle,
-              }}
-            />
+          <FocusRing within>
             <div
-              css={STYLES_UNIT}
-              ref={(c) => {
-                this._unit = c;
+              css={[STYLES_INPUT, this.props.inputCss]}
+              style={{
+                position: "relative",
+                boxShadow: this.props.validation
+                  ? `0 1px 4px rgba(0, 0, 0, 0.07), inset 0 0 0 2px ${
+                      INPUT_COLOR_MAP[this.props.validation]
+                    }`
+                  : null,
+                ...this.props.style,
               }}
             >
-              {this.props.unit}
+              <input
+                ref={(c) => {
+                  this._input = c;
+                }}
+                css={[INPUT_STYLES, this._isPin && STYLES_PIN_INPUT]}
+                autoFocus={this.props.autoFocus}
+                value={this._isPin ? this._formatPin(this.props.value) : this.props.value}
+                name={this.props.name}
+                type={this._isPin ? "text" : this.props.type}
+                placeholder={this.props.placeholder}
+                onChange={this._handleChange}
+                onFocus={
+                  this.props.autoHighlight
+                    ? () => {
+                        this._input.select();
+                      }
+                    : this.props.onFocus
+                }
+                onBlur={this.props.onBlur}
+                onKeyDown={this._handleKeyDown}
+                autoComplete="off"
+                disabled={this.props.disabled}
+                readOnly={this.props.readOnly}
+                required={this.props.required}
+                maxLength={this.props.maxLength}
+                style={{
+                  width: this.props.copyable || this.props.icon ? "calc(100% - 32px)" : "100%",
+                  ...this.props.textStyle,
+                }}
+              />
+              <div
+                css={STYLES_UNIT}
+                ref={(c) => {
+                  this._unit = c;
+                }}
+              >
+                {this.props.unit}
+              </div>
+              {this.props.unit ? null : this.props.icon ? (
+                <this.props.icon
+                  height="16px"
+                  css={STYLES_ICON}
+                  style={{ cursor: (this.props.onClickIcon || this.props.onSubmit) && "pointer" }}
+                  onClick={this.props.onClickIcon || this.props.onSubmit || this._handleSubmit}
+                />
+              ) : this.props.copyable ? (
+                <SVG.CopyAndPaste
+                  height="16px"
+                  css={STYLES_ICON}
+                  style={{ cursor: "pointer" }}
+                  onClick={this._handleCopy}
+                />
+              ) : null}
             </div>
-            {this.props.unit ? null : this.props.icon ? (
-              <this.props.icon
-                height="16px"
-                css={STYLES_ICON}
-                style={{ cursor: (this.props.onClickIcon || this.props.onSubmit) && "pointer" }}
-                onClick={this.props.onClickIcon || this.props.onSubmit || this._handleSubmit}
-              />
-            ) : this.props.copyable ? (
-              <SVG.CopyAndPaste
-                height="16px"
-                css={STYLES_ICON}
-                style={{ cursor: "pointer" }}
-                onClick={this._handleCopy}
-              />
-            ) : null}
-          </div>
+          </FocusRing>
         </div>
       </>
     );

--- a/components/system/components/Textarea.js
+++ b/components/system/components/Textarea.js
@@ -20,9 +20,7 @@ const STYLES_TEXTAREA = css`
   font-size: 16px;
   align-items: center;
   justify-content: flex-start;
-  outline: 0;
   border: 0;
-  transition: 200ms ease all;
   padding: 9px 12px 11px;
   box-shadow: 0 0 0 1px ${Constants.semantic.borderGrayLight} inset;
 

--- a/components/system/components/Typography.js
+++ b/components/system/components/Typography.js
@@ -191,16 +191,16 @@ export const H5 = React.forwardRef(({ as = "h5", nbrOflines, children, color, ..
   );
 });
 
-export const H6 = ({ as = "h6", nbrOflines, children, color, ...props }) => {
+export const H6 = React.forwardRef(({ as = "h6", nbrOflines, children, color, ...props }, ref) => {
   const TRUNCATE_STYLE = React.useMemo(() => truncateElements(nbrOflines), [nbrOflines]);
   const COLOR_STYLES = useColorProp(color);
 
   return jsx(
     as,
-    { ...props, css: [Styles.H6, TRUNCATE_STYLE, COLOR_STYLES, props?.css] },
+    { ...props, css: [Styles.H6, TRUNCATE_STYLE, COLOR_STYLES, props?.css], ref },
     children
   );
-};
+});
 
 export const P1 = ({ as = "p", nbrOflines, children, color, ...props }) => {
   const TRUNCATE_STYLE = React.useMemo(() => truncateElements(nbrOflines), [nbrOflines]);

--- a/components/system/components/fragments/Tooltip.js
+++ b/components/system/components/fragments/Tooltip.js
@@ -2,7 +2,8 @@ import * as React from "react";
 
 import { css } from "@emotion/react";
 import { ModalPortal } from "~/components/core/ModalPortal";
-import { useCombinedRefs, useEscapeKey, useEventListener } from "~/common/hooks";
+import { mergeRefs } from "~/common/utilities";
+import { useEscapeKey, useEventListener } from "~/common/hooks";
 import { Boundary } from "~/components/system/components/fragments/Boundary";
 import { motion } from "framer-motion";
 
@@ -34,8 +35,7 @@ export function Root({ children, vertical = "below", horizontal = "right" }) {
 export const Trigger = React.forwardRef(({ children, ...props }, forwardedRef) => {
   const { setTriggerRef, showTooltip, hideTooltip } = useTooltipContext();
 
-  const innerRef = React.useRef();
-  const ref = useCombinedRefs(innerRef, children.ref, forwardedRef);
+  const ref = React.useRef();
 
   React.useEffect(() => {
     if (ref.current) setTriggerRef(ref);
@@ -50,7 +50,7 @@ export const Trigger = React.forwardRef(({ children, ...props }, forwardedRef) =
   return React.cloneElement(React.Children.only(children), {
     role: "tooltip",
     ...props,
-    ref,
+    ref: mergeRefs([ref, forwardedRef, children.ref]),
   });
 });
 /* -------------------------------------------------------------------------------------------------

--- a/components/system/components/fragments/Tooltip.js
+++ b/components/system/components/fragments/Tooltip.js
@@ -1,0 +1,204 @@
+import * as React from "react";
+
+import { css } from "@emotion/react";
+import { ModalPortal } from "~/components/core/ModalPortal";
+import { useEscapeKey, useEventListener } from "~/common/hooks";
+import { Boundary } from "~/components/system/components/fragments/Boundary";
+import { motion } from "framer-motion";
+
+/* -------------------------------------------------------------------------------------------------
+ *  Root
+ * -----------------------------------------------------------------------------------------------*/
+
+const TooltipContext = React.createContext({});
+const useTooltipContext = () => React.useContext(TooltipContext);
+
+export function Root({ children, vertical = "below", horizontal = "right" }) {
+  const [state, setState] = React.useState({ isOpen: false, triggerRef: { current: null } });
+  const showTooltip = () => setState((prev) => ({ ...prev, isOpen: true }));
+  const hideTooltip = () => setState((prev) => ({ ...prev, isOpen: false }));
+  const setTriggerRef = (triggerRef) => setState((prev) => ({ ...prev, triggerRef }));
+
+  const contextValue = React.useMemo(
+    () => ({ showTooltip, hideTooltip, setTriggerRef, vertical, horizontal, ...state }),
+    [state, vertical, horizontal]
+  );
+
+  return <TooltipContext.Provider value={contextValue}>{children}</TooltipContext.Provider>;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ *  Trigger
+ * -----------------------------------------------------------------------------------------------*/
+
+export function Trigger({ children, ...props }) {
+  const { setTriggerRef, showTooltip, hideTooltip } = useTooltipContext();
+
+  const ref = React.useRef();
+  React.useEffect(() => {
+    if (ref.current) setTriggerRef(ref);
+  }, []);
+
+  useEventListener({ type: "mouseenter", handler: showTooltip, ref });
+  useEventListener({ type: "mouseleave", handler: hideTooltip, ref });
+  useEventListener({ type: "click", handler: hideTooltip, ref });
+  useEventListener({ type: "focus", handler: showTooltip, ref });
+  useEventListener({ type: "blur", handler: hideTooltip, ref });
+
+  return React.cloneElement(React.Children.only(children), {
+    role: "tooltip",
+    ...props,
+    ref,
+  });
+}
+
+/* -------------------------------------------------------------------------------------------------
+ *  Content
+ * -----------------------------------------------------------------------------------------------*/
+const getTooltipPosition = (triggerElement, TooltipElement, vertical, horizontal) => {
+  let yOffset = window.pageYOffset;
+  let xOffset = window.pageXOffset;
+
+  const triggerRect = triggerElement.getBoundingClientRect();
+  const tooltipRect = TooltipElement.getBoundingClientRect();
+
+  let position = {};
+  switch (vertical) {
+    case "above":
+      position.top = `${triggerRect.top - tooltipRect.height + yOffset}px`;
+      break;
+    case "up":
+      position.top = `${triggerRect.bottom - tooltipRect.height + yOffset}px`;
+      break;
+    case "center":
+      position.top = `${
+        triggerRect.top + 0.5 * triggerRect.height - 0.5 * tooltipRect.height + yOffset
+      }px`;
+      break;
+    case "down":
+      position.top = `${triggerRect.top + yOffset}px`;
+      break;
+    case "below":
+      position.top = `${triggerRect.bottom + yOffset}px`;
+      break;
+  }
+  switch (horizontal) {
+    case "far-left":
+      position.left = `${triggerRect.left - tooltipRect.width + xOffset}px`;
+      break;
+    case "left":
+      position.left = `${triggerRect.right - tooltipRect.width + xOffset}px`;
+      break;
+    case "center":
+      position.left = `${
+        triggerRect.left + 0.5 * triggerRect.width - 0.5 * tooltipRect.width + xOffset
+      }px`;
+      break;
+    case "right":
+      position.left = `${triggerRect.left + xOffset}px`;
+      break;
+    case "far-right":
+      position.left = `${triggerRect.right + xOffset}px`;
+      break;
+  }
+  return position;
+};
+
+const adjustTooltipDirection = (triggerElement, TooltipElement, vertical, horizontal) => {
+  let yOffset = triggerElement ? triggerElement.scrollTop : window.pageYOffset;
+  let xOffset = triggerElement ? triggerElement.scrollLeft : window.pageXOffset;
+
+  const triggerRect = triggerElement.getBoundingClientRect();
+  const tooltipRect = TooltipElement.getBoundingClientRect();
+
+  if (!vertical) {
+    if (tooltipRect.height > triggerRect.top + yOffset) {
+      vertical = "below";
+    } else {
+      vertical = "above";
+    }
+  }
+  if (!horizontal) {
+    if (tooltipRect.width / 2 > triggerRect.left + triggerRect.width / 2 + xOffset) {
+      horizontal = "right";
+    } else if (tooltipRect.width / 2 > triggerRect.right + triggerRect.width / 2 + xOffset) {
+      horizontal = "left";
+    } else {
+      horizontal = "center";
+    }
+  }
+  return { vertical, horizontal };
+};
+
+const STYLES_CONTENT_WRAPPER = (theme) => css`
+  z-index: 2342342342;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border-radius: 8px;
+  border: 1px solid ${theme.semantic.borderGrayLight4};
+  padding: 6px 8px;
+
+  box-shadow: ${theme.shadow.darkSmall};
+  background-color: ${theme.semantic.bgWhite};
+  @supports ((-webkit-backdrop-filter: blur(75px)) or (backdrop-filter: blur(75px))) {
+    -webkit-backdrop-filter: blur(75px);
+    backdrop-filter: blur(75px);
+  }
+`;
+
+function ContentWrapper({ children, css, style, ...props }) {
+  const { hideTooltip, triggerRef, horizontal, vertical } = useTooltipContext();
+  const [position, setPosition] = React.useState();
+
+  const ref = React.useRef();
+
+  React.useLayoutEffect(() => {
+    if (ref) {
+      const direction = adjustTooltipDirection(
+        triggerRef.current,
+        ref.current,
+        vertical,
+        horizontal
+      );
+      const position = getTooltipPosition(
+        triggerRef.current,
+        ref.current,
+        direction.vertical,
+        direction.horizontal
+      );
+      setPosition(position);
+    }
+  }, []);
+
+  useEscapeKey(hideTooltip);
+  useEventListener({ type: "scroll", handler: hideTooltip });
+
+  return (
+    <Boundary enabled={true} onOutsideRectEvent={hideTooltip}>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        css={[STYLES_CONTENT_WRAPPER, css]}
+        ref={ref}
+        style={{ ...style, top: position?.top, left: position?.left }}
+        hidden={!position}
+        {...props}
+      >
+        {children}
+      </motion.div>
+    </Boundary>
+  );
+}
+
+export function Content({ children, ...props }) {
+  const { isOpen } = useTooltipContext();
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalPortal>
+      <ContentWrapper {...props}>{children}</ContentWrapper>
+    </ModalPortal>
+  );
+}

--- a/components/system/components/fragments/Tooltip.js
+++ b/components/system/components/fragments/Tooltip.js
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { css } from "@emotion/react";
 import { ModalPortal } from "~/components/core/ModalPortal";
-import { useEscapeKey, useEventListener } from "~/common/hooks";
+import { useCombinedRefs, useEscapeKey, useEventListener } from "~/common/hooks";
 import { Boundary } from "~/components/system/components/fragments/Boundary";
 import { motion } from "framer-motion";
 
@@ -31,10 +31,12 @@ export function Root({ children, vertical = "below", horizontal = "right" }) {
  *  Trigger
  * -----------------------------------------------------------------------------------------------*/
 
-export function Trigger({ children, ...props }) {
+export const Trigger = React.forwardRef(({ children, ...props }, forwardedRef) => {
   const { setTriggerRef, showTooltip, hideTooltip } = useTooltipContext();
 
-  const ref = React.useRef();
+  const innerRef = React.useRef();
+  const ref = useCombinedRefs(innerRef, children.ref, forwardedRef);
+
   React.useEffect(() => {
     if (ref.current) setTriggerRef(ref);
   }, []);
@@ -50,8 +52,7 @@ export function Trigger({ children, ...props }) {
     ...props,
     ref,
   });
-}
-
+});
 /* -------------------------------------------------------------------------------------------------
  *  Content
  * -----------------------------------------------------------------------------------------------*/

--- a/components/system/index.js
+++ b/components/system/index.js
@@ -26,6 +26,7 @@ import { GlobalNotification } from "~/components/system/components/GlobalNotific
 
 // NOTE(jim): Components
 import {
+  ButtonPrimitive,
   ButtonPrimary,
   ButtonPrimaryFull,
   ButtonSecondary,
@@ -124,6 +125,7 @@ export {
   // GlobalCarousel,
   GlobalNotification,
   // NOTE(jim): Components
+  ButtonPrimitive,
   ButtonPrimary,
   ButtonPrimaryFull,
   ButtonSecondary,

--- a/scenes/SceneFilesFolder.js
+++ b/scenes/SceneFilesFolder.js
@@ -69,6 +69,7 @@ export default function SceneFilesFolder({ viewer, page, onAction, isMobile }) {
                 isOwner={true}
                 items={objects}
                 onAction={onAction}
+                isMobile={isMobile}
                 viewer={viewer}
                 page={page}
                 view="grid"

--- a/scenes/SceneSlate.js
+++ b/scenes/SceneSlate.js
@@ -482,6 +482,7 @@ class SlatePage extends React.Component {
                 view={"grid"}
                 isOwner={isOwner}
                 page={this.props.page}
+                isMobile={this.props.isMobile}
               />
             </div>
           </>

--- a/vendor/react-textarea-autosize.js
+++ b/vendor/react-textarea-autosize.js
@@ -1,10 +1,14 @@
 import * as React from "react";
 
-import calculateNodeHeight, {
-  purgeCache,
-} from "~/vendor/calculate-node-height";
+import calculateNodeHeight, { purgeCache } from "~/vendor/calculate-node-height";
+import { FocusRing } from "~/components/core/FocusRing";
+import { css } from "@emotion/react";
 
 const noop = () => {};
+
+const STYLES_TEXTAREA = css`
+  outline: 0;
+`;
 
 let uid = 0;
 
@@ -36,21 +40,28 @@ export default class TextareaAutosize extends React.Component {
       minRows,
       onHeightChange,
       useCacheForDOMMeasurements,
+      css,
       ...props
     } = this.props;
 
     props.style = { ...props.style, height: this.state.height };
 
-    const maxHeight = Math.max(
-      props.style.maxHeight || Infinity,
-      this.state.maxHeight
-    );
+    const maxHeight = Math.max(props.style.maxHeight || Infinity, this.state.maxHeight);
 
     if (maxHeight < this.state.height) {
       props.style.overflow = "hidden";
     }
 
-    return <textarea {...props} onChange={this._onChange} ref={this._onRef} />;
+    return (
+      <FocusRing>
+        <textarea
+          {...props}
+          css={[STYLES_TEXTAREA, css]}
+          onChange={this._onChange}
+          ref={this._onRef}
+        />
+      </FocusRing>
+    );
   }
 
   componentDidMount() {
@@ -123,13 +134,7 @@ export default class TextareaAutosize extends React.Component {
       return;
     }
 
-    const {
-      height,
-      minHeight,
-      maxHeight,
-      rowCount,
-      valueRowCount,
-    } = nodeHeight;
+    const { height, minHeight, maxHeight, rowCount, valueRowCount } = nodeHeight;
 
     this.rowCount = rowCount;
     this.valueRowCount = valueRowCount;


### PR DESCRIPTION
Branched form #1037 
This PR resolves #1032
### New Features
* Added FocusRing component

Displays a focus ring if its child receives focus via a keyboard. This component doesn't create a dom node, it uses its child component to detect focus events. Therefore the child component forward its ref
```jsx
const Button = (props) => (
  <FocusRing>
    <button {...props} />
  </FocusRing>
);
```
FocusRing can also detect focus within its children, similar to the `:focus-within` selector. You can toggle it by using the `within` prop

```jsx
const STYLES_FOCUS_RING = css`
  outline: 2px solid red;
`;

const Input = () => (
  <FocusRing within css={STYLES_FOCUS_RING}>
    <input  />
    <button>
      <Icon />
    </button>
  </FocusRing>
);
```

* RovingTabIndex component

Navigate a list's children using the arrow keys. Navigation's direction is managed by the `axis` prop, `horizontal` using the left and right arrows, or `vertical` with the up and down arrows. `RovingTabIndex.Item` should wrap directly the focusable element, and its child should forward its ref. 
This component manages the navigation order by keeping track of each focusable element in the list using the `index` prop. Upon hitting the arrow key, we'll update the focusable element's tabindex to 0 and focus it manually

```jsx
const Navigation = () => (
  <RovingTabIndex.Provider axis="vertical">
    <RovingTabIndex.List as="ul">
      {items.map((item, index) => (
        <li key={item.id}>
          <RovingTabIndex.Item index={index}>
            <button>{item.name}</button>
          </RovingTabIndex.Item>
        </li>
      ))}
    </RovingTabIndex.List>
  </RovingTabIndex.Provider>
);
```

Currently works in the tags jumper and in the filter sidebar and popup.

https://user-images.githubusercontent.com/39884652/148104365-dd2b161f-7b4d-4993-8ee6-6ae84bfd32b5.mov



* New Tooltip component

Follow guidelines from [wai-aria/tooltip](https://www.w3.org/TR/wai-aria-practices/#tooltip) . Similar to the jumper component, you need to import all parts to build a tooltip. Tooltip's placement is managed by the `vertical` and `horizontal` props.
Similar to previous components, `Tooltip.Trigger` doesn't create a dom node, so its child should forward its ref
```jsx
const ShortcutTooltip = () => (
  <Tooltip.Root vertical="below" horizontal="right">
    <Tooltip.Trigger aria-describedby="trigger-tooltip">
      <button>
        <Icon />
      </button>
    </Tooltip.Trigger>
    <Tooltip.Content>
      <System.H6 id="trigger-tooltip" as="p" color="textGrayDark">
        Click to save
      </System.H6>
    </Tooltip.Content>
  </Tooltip.Root>
);
```

### Additional changes
* Toggle the filter sidebar via `\` key
* Ability to collapse and expand filters
* Added keyboard shortcuts for carousel's actions
     * `e` for edit info jumper
     * `s` for share jumper
     * `t` for tags jumper
     * `i` for more info jumper
* Show different search scopes in the filter's header
* Accessibility changes to the carousel and jumpers following [wai-aria](https://www.w3.org/TR/wai-aria-practices-1.1/) guides